### PR TITLE
fix: allow pnpm git dep prepare scripts + resolve missing SDK exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,11 @@
     "api",
     "defi",
     "perpetuals"
-  ]
+  ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@percolator/sdk",
+      "@percolator/shared"
+    ]
+  }
 }


### PR DESCRIPTION
Fixes CI build failure with two root causes:

1. **ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED** — pnpm 10 blocks prepare scripts for git-hosted deps. Adding `pnpm.onlyBuiltDependencies` allowlist fixes this.

2. **Missing SDK exports** (fetchSlab, parseHeader, parseConfig, parseEngine, resolvePrice, PriceRouterResult) — these are all properly exported from `@percolator/sdk`, but the SDK's `prepare` script (`tsup`) wasn't running during install due to issue #1, so the built output wasn't available.