### PR TITLE
fix: explicitly build SDK + shared git deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build git dependencies
+        run: |
+          # pnpm 10 may skip prepare scripts for git deps; build them explicitly
+          SHARED=$(node -e "console.log(require.resolve('@percolator/shared/package.json').replace('/package.json',''))")
+          SDK=$(node -e "console.log(require.resolve('@percolator/sdk/package.json').replace('/package.json',''))")
+          (cd "$SHARED" && npx tsc)
+          (cd "$SDK" && npx tsup && npx tsc --emitDeclarationOnly --declaration --outDir dist)
       - run: pnpm build
       - run: pnpm test
 


### PR DESCRIPTION
pnpm 10 skips prepare scripts for git dependencies. Adds explicit build step after install to compile @percolator/sdk (tsup) and @percolator/shared (tsc) before main build. Fixes TS2305 export errors.