### PR TITLE
fix: update @percolator/shared lockfile (base58 regex fix)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/dec29c31c54cb8726b8d183a3a8456cb2e677836(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@percolator/shared':
         specifier: github:dcccrypto/percolator-shared
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/1c78416cd46d2cce2acfd67bb7f861e9f6f1a135(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/502756a2f63851b4127d2988b0b884f187401077(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sentry/node':
         specifier: ^10.39.0
         version: 10.40.0
@@ -446,12 +446,16 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/95789ceff30adb5d93bf13192ba708f86494ebb4':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/95789ceff30adb5d93bf13192ba708f86494ebb4}
+    version: 0.1.0
+
   '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/dec29c31c54cb8726b8d183a3a8456cb2e677836':
     resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/dec29c31c54cb8726b8d183a3a8456cb2e677836}
     version: 0.1.0
 
-  '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/1c78416cd46d2cce2acfd67bb7f861e9f6f1a135':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/1c78416cd46d2cce2acfd67bb7f861e9f6f1a135}
+  '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/502756a2f63851b4127d2988b0b884f187401077':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/502756a2f63851b4127d2988b0b884f187401077}
     version: 0.1.0
 
   '@prisma/instrumentation@7.2.0':
@@ -1667,6 +1671,17 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
 
+  '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/95789ceff30adb5d93bf13192ba708f86494ebb4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
   '@percolator/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/dec29c31c54cb8726b8d183a3a8456cb2e677836(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -1678,9 +1693,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/1c78416cd46d2cce2acfd67bb7f861e9f6f1a135(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/502756a2f63851b4127d2988b0b884f187401077(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@percolator/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/dec29c31c54cb8726b8d183a3a8456cb2e677836(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@percolator/sdk': https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/95789ceff30adb5d93bf13192ba708f86494ebb4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sentry/node': 10.40.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@supabase/supabase-js': 2.97.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)


### PR DESCRIPTION
Updates lockfile to pull in dcccrypto/percolator-shared#4 which fixes the base58 regex in network validation. Without this, startup crashes because PROGRAM_ID with lowercase chars fails validation.