### PR TITLE
fix: return default data instead of 404 for uncranked markets (PERC-182)

### DIFF
--- a/src/routes/funding.ts
+++ b/src/routes/funding.ts
@@ -99,10 +99,29 @@ export function fundingRoutes(): Hono {
       }
 
       if (!stats) {
-        return c.json({ 
-          error: "Market stats not found",
-          hint: "Market may not have been cranked yet or does not exist"
-        }, 404);
+        // Return default zeroed data instead of 404 — market exists but hasn't been cranked yet.
+        // This prevents console error floods from frontend polling.
+        return c.json({
+          slabAddress: slab,
+          currentRateBpsPerSlot: 0,
+          hourlyRatePercent: 0,
+          dailyRatePercent: 0,
+          annualizedPercent: 0,
+          netLpPosition: "0",
+          last24hHistory: [],
+          metadata: {
+            dataPoints24h: 0,
+            note: "Market has not been cranked yet — funding data will appear after first crank.",
+            explanation: {
+              rateBpsPerSlot: "Funding rate in basis points per slot (1 bps = 0.01%)",
+              hourly: "Rate * 9,000 slots/hour (assumes 400ms slots)",
+              daily: "Rate * 216,000 slots/day",
+              annualized: "Rate * 78,840,000 slots/year",
+              sign: "Positive = longs pay shorts | Negative = shorts pay longs",
+              inventory: "Driven by net LP position (LP inventory imbalance)",
+            }
+          }
+        });
       }
 
       // Parse current funding data


### PR DESCRIPTION
## Problem
`/api/funding/:slab` returns 404 when `market_stats` has no row (market not yet cranked). Frontend polls every 30s, flooding browser console with red 404 errors.

## Fix
Return 200 with zeroed funding data + a `metadata.note` explaining the market hasn't been cranked. Frontend already handles this shape correctly — the fallback to on-chain data will still work.

## Testing
- TypeScript compiles clean ✅
- Response shape matches existing `/funding/:slab` contract

Fixes PERC-182