### PR TITLE
test(PERC-518): add ip-blocklist middleware tests + trigger Railway rebuild

### DIFF
--- a/tests/middleware/ip-blocklist.test.ts
+++ b/tests/middleware/ip-blocklist.test.ts
@@ -1,0 +1,128 @@
+/**
+ * ip-blocklist middleware tests.
+ *
+ * The middleware captures IP_BLOCKLIST and TRUSTED_PROXY_DEPTH at module-load
+ * time, so we must reset modules and re-import per test to pick up env changes.
+ *
+ * X-Forwarded-For parsing (PROXY_DEPTH=N):
+ *   idx = max(0, ips.length - N)
+ *   so the resolved client IP is ips[idx] — the Nth-from-the-right entry.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+
+type MiddlewareFn = (c: unknown, next: unknown) => Promise<unknown>;
+
+async function buildApp(
+  blocklist?: string,
+  proxyDepth?: string,
+): Promise<Hono> {
+  // Set env vars BEFORE importing the module so constants are captured fresh.
+  if (blocklist !== undefined) {
+    process.env.IP_BLOCKLIST = blocklist;
+  } else {
+    delete process.env.IP_BLOCKLIST;
+  }
+  if (proxyDepth !== undefined) {
+    process.env.TRUSTED_PROXY_DEPTH = proxyDepth;
+  } else {
+    delete process.env.TRUSTED_PROXY_DEPTH;
+  }
+
+  vi.resetModules();
+  const { ipBlocklistMiddleware } = await import(
+    "../../src/middleware/ip-blocklist.js"
+  );
+
+  const app = new Hono();
+  app.use("*", (ipBlocklistMiddleware as () => MiddlewareFn)());
+  app.get("/test", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("ipBlocklistMiddleware", () => {
+  let savedEnv: typeof process.env;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    // Restore env and clear module cache so next test starts clean.
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+    vi.resetModules();
+  });
+
+  it("allows all requests when IP_BLOCKLIST is empty", async () => {
+    const app = await buildApp("");
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("allows requests when IP_BLOCKLIST is not set", async () => {
+    const app = await buildApp(undefined);
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks a single matching IP (PROXY_DEPTH=1)", async () => {
+    // PROXY_DEPTH=1: idx = max(0, n-1)
+    // With "10.0.0.1, 5.6.7.8": n=2, idx=1 → resolved IP = "5.6.7.8"
+    const app = await buildApp("5.6.7.8", "1");
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "10.0.0.1, 5.6.7.8" },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Forbidden" });
+  });
+
+  it("allows a non-blocked IP (PROXY_DEPTH=1)", async () => {
+    // Resolved IP = "9.9.9.9" (rightmost) → not blocked
+    const app = await buildApp("5.6.7.8", "1");
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "10.0.0.1, 9.9.9.9" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks any of multiple comma-separated IPs in blocklist", async () => {
+    // Resolved IP = "2.2.2.2" (rightmost with PROXY_DEPTH=1)
+    const app = await buildApp("1.1.1.1, 2.2.2.2, 5.6.7.8", "1");
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "8.8.8.8, 2.2.2.2" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows IP not in a multi-entry blocklist", async () => {
+    const app = await buildApp("1.1.1.1, 2.2.2.2", "1");
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "8.8.8.8, 3.3.3.3" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("falls back to x-real-ip when TRUSTED_PROXY_DEPTH=0", async () => {
+    const app = await buildApp("5.6.7.8", "0");
+    const res = await app.request("/test", {
+      headers: { "x-real-ip": "5.6.7.8" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows requests with unknown IP when no forwarding headers present", async () => {
+    // No x-forwarded-for or x-real-ip → resolved as "unknown" → never blocked
+    const app = await buildApp("5.6.7.8", "1");
+    const res = await app.request("/test", {});
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

The IP blocklist middleware (`src/middleware/ip-blocklist.ts`) was already implemented and wired into `src/index.ts` (commit `597f5c1`), but had **zero test coverage**. This PR adds 8 tests covering all code paths.

Additionally, Railway manual redeployments were failing — this git push triggers a clean CI-driven rebuild.

## What changed
- `tests/middleware/ip-blocklist.test.ts` — 8 new test cases

## Test cases
- Empty / unset `IP_BLOCKLIST` env → allow all traffic
- Single blocked IP with `PROXY_DEPTH=1` (x-forwarded-for)
- Non-blocked IP with same config
- Multi-entry blocklist: block matching, allow non-matching  
- `TRUSTED_PROXY_DEPTH=0` fallback to `x-real-ip`
- Unknown IP (no forwarding headers) → allow (never block unknown)

## Test strategy
Uses `vi.resetModules()` + dynamic import per test — required because `PROXY_DEPTH` and the blocklist `Set` are captured at module load time.

## CI / Railway
All 117 tests pass locally. This push triggers Railway's CI build pipeline for a clean redeploy.

Closes: PERC-518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test suite added for IP-based access control, ensuring robust validation across multiple scenarios. Tests cover empty blocklists, single and multiple IP entries, configurable proxy depth settings, fallback header mechanisms, edge cases with missing headers, and HTTP response verification. Each test independently validates blocking and allowing behaviors with proper configuration reset between cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->