### PR TITLE
fix(PERC-660): add 60 req/min rate limit to /stats endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { openInterestRoutes } from "./routes/open-interest.js";
 import { statsRoutes } from "./routes/stats.js";
 import { docsRoutes } from "./routes/docs.js";
 import { setupWebSocket } from "./routes/ws.js";
-import { readRateLimit, writeRateLimit } from "./middleware/rate-limit.js";
+import { readRateLimit, writeRateLimit, createRateLimit } from "./middleware/rate-limit.js";
 import { cacheMiddleware } from "./middleware/cache.js";
 import { ipBlocklistMiddleware } from "./middleware/ip-blocklist.js";
 
@@ -125,6 +125,11 @@ app.use("*", async (c, next) => {
   }
   return writeRateLimit()(c, next);
 });
+
+// Per-endpoint rate limits (stricter than the global 100 req/min read limit)
+// Applied before caching so scrapers are throttled even on cache hits.
+// - /stats — 60 req/min (mirrors /api/trader/:wallet/trades, security #1031)
+app.use("/stats", createRateLimit(60));
 
 // Response Caching Middleware (applied per-route)
 // Cache read-heavy endpoints with varying TTLs:

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -131,3 +131,44 @@ export function writeRateLimit() {
     return next();
   };
 }
+
+/**
+ * Create a per-endpoint rate limiter with a custom request limit per minute.
+ *
+ * Each call to createRateLimit() returns a middleware backed by its own
+ * isolated bucket map, so it enforces the limit independently of the
+ * global readRateLimit / writeRateLimit buckets.
+ *
+ * Example: apply 60 req/min to /stats
+ *   app.use("/stats", createRateLimit(60));
+ */
+export function createRateLimit(limit: number) {
+  const buckets = new Map<string, RateBucket>();
+
+  // Clean up expired buckets every 5 minutes
+  setInterval(() => {
+    const now = Date.now();
+    for (const [k, v] of buckets) if (v.resetAt <= now) buckets.delete(k);
+  }, 5 * 60_000);
+
+  return async (c: Context, next: Next) => {
+    const ip = getClientIp(c);
+    const result = checkLimit(buckets, ip, limit);
+
+    // Set rate limit headers
+    c.header("X-RateLimit-Limit", result.limit.toString());
+    c.header("X-RateLimit-Remaining", result.remaining.toString());
+    c.header("X-RateLimit-Reset", result.reset.toString());
+
+    if (!result.allowed) {
+      logger.warn("Endpoint rate limit exceeded", {
+        ip,
+        path: c.req.path,
+        limit,
+      });
+      return c.json({ error: "Rate limit exceeded" }, 429);
+    }
+
+    return next();
+  };
+}

--- a/tests/middleware/rate-limit.test.ts
+++ b/tests/middleware/rate-limit.test.ts
@@ -8,7 +8,7 @@ vi.mock("@percolator/shared", () => ({
   config: { supabaseUrl: "http://test", supabaseKey: "test", rpcUrl: "http://test" },
 }));
 
-import { readRateLimit, writeRateLimit } from "../../src/middleware/rate-limit.js";
+import { readRateLimit, writeRateLimit, createRateLimit } from "../../src/middleware/rate-limit.js";
 
 describe("rate-limit middleware", () => {
   beforeEach(() => {
@@ -158,6 +158,93 @@ describe("rate-limit middleware", () => {
 
       const res = await app.request("/test", { method: "POST" });
       expect(res.status).toBe(429);
+    });
+  });
+
+  describe("createRateLimit (custom per-endpoint limiter)", () => {
+    it("should allow requests within the custom limit", async () => {
+      const app = new Hono();
+      app.get("/stats", createRateLimit(60), (c) => c.json({ success: true }));
+
+      // 60 requests should all pass
+      for (let i = 0; i < 60; i++) {
+        const res = await app.request("/stats", {
+          headers: { "x-forwarded-for": "10.0.0.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it("should return 429 on the (limit + 1)th request", async () => {
+      const app = new Hono();
+      app.get("/stats", createRateLimit(60), (c) => c.json({ success: true }));
+
+      for (let i = 0; i < 60; i++) {
+        await app.request("/stats", {
+          headers: { "x-forwarded-for": "10.0.0.2" },
+        });
+      }
+
+      const res = await app.request("/stats", {
+        headers: { "x-forwarded-for": "10.0.0.2" },
+      });
+      expect(res.status).toBe(429);
+      const data = await res.json();
+      expect(data).toEqual({ error: "Rate limit exceeded" });
+    });
+
+    it("should set X-RateLimit-* headers", async () => {
+      const app = new Hono();
+      app.get("/stats", createRateLimit(60), (c) => c.json({ success: true }));
+
+      const res = await app.request("/stats", {
+        headers: { "x-forwarded-for": "10.0.0.3" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+      expect(res.headers.get("X-RateLimit-Remaining")).toBe("59");
+      expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+    });
+
+    it("should use isolated buckets — does not share state with readRateLimit", async () => {
+      // Exhaust the custom limiter (limit=2 for speed)
+      const app = new Hono();
+      const customMw = createRateLimit(2);
+      app.get("/stats", customMw, (c) => c.json({ endpoint: "custom" }));
+      app.get("/other", readRateLimit(), (c) => c.json({ endpoint: "global" }));
+
+      await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.4" } });
+      await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.4" } });
+
+      // Custom limiter is exhausted
+      const statsRes = await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.4" } });
+      expect(statsRes.status).toBe(429);
+
+      // Global readRateLimit bucket for same IP is unaffected
+      const otherRes = await app.request("/other", { headers: { "x-forwarded-for": "10.0.0.4" } });
+      expect(otherRes.status).toBe(200);
+    });
+
+    it("should reset after the 60-second window", async () => {
+      vi.useFakeTimers();
+
+      const app = new Hono();
+      app.get("/stats", createRateLimit(2), (c) => c.json({ success: true }));
+
+      // Exhaust
+      await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.5" } });
+      await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.5" } });
+
+      let res = await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.5" } });
+      expect(res.status).toBe(429);
+
+      // Advance past 60s window
+      vi.advanceTimersByTime(61_000);
+
+      res = await app.request("/stats", { headers: { "x-forwarded-for": "10.0.0.5" } });
+      expect(res.status).toBe(200);
+
+      vi.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
## Summary
Security issue #1031: `/api/stats` had no per-endpoint rate limiting, only the global 100 req/min read limit.

## Changes
- **`src/middleware/rate-limit.ts`** — adds `createRateLimit(limit)` factory that creates an isolated per-endpoint bucket map independent of the global read/write buckets
- **`src/index.ts`** — applies `createRateLimit(60)` to `/stats` before caching middleware so throttling is enforced even on cache hits
- **`tests/middleware/rate-limit.test.ts`** — 5 new tests: within-limit pass, 429 on limit+1, header correctness, bucket isolation from `readRateLimit`, window reset

## How to Test
```bash
# Run test suite
pnpm test

# Manual: hammer /stats and confirm 429 after 60 requests
for i in {1..65}; do curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/stats; done
```

## Test Results
122/122 tests pass.