### PR TITLE
fix(ip-blocklist): normalize and validate exact-IP entries

### DIFF
--- a/src/middleware/ip-blocklist.ts
+++ b/src/middleware/ip-blocklist.ts
@@ -66,7 +66,11 @@ function parseEntry(entry: string): ParsedEntry | null {
     const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
     return { type: "cidr", raw: entry, network: (network & mask) >>> 0, mask };
   }
-  return { type: "exact", raw: entry, ip: entry };
+  // Exact entry: normalize (strip ::ffff: IPv6-mapped prefix) and validate
+  // so that operator-supplied entries match normalized client IPs symmetrically.
+  const normalized = normalizeIp(entry);
+  if (ipToInt(normalized) === -1) return null;
+  return { type: "exact", raw: entry, ip: normalized };
 }
 
 const PARSED_BLOCKLIST: ParsedEntry[] = RAW_BLOCKLIST.map((entry) => {
@@ -162,5 +166,5 @@ export function ipBlocklist() {
  * handler, which runs before Hono middleware gets a chance to fire.
  */
 export function isClientIpBlocked(ip: string): boolean {
-  return isBlocked(ip);
+  return isBlocked(normalizeIp(ip));
 }

--- a/tests/middleware/ip-blocklist.test.ts
+++ b/tests/middleware/ip-blocklist.test.ts
@@ -178,4 +178,45 @@ describe("isClientIpBlocked", () => {
     expect(check("192.168.1.55")).toBe(true);
     expect(check("192.168.2.1")).toBe(false);
   });
+
+  it("matches IPv6-mapped IPv4 client against bare IPv4 blocklist entry", async () => {
+    const check = await loadIsClientIpBlocked("88.97.223.158");
+    expect(check("::ffff:88.97.223.158")).toBe(true);
+  });
+
+  it("matches bare IPv4 client against IPv6-mapped IPv4 blocklist entry", async () => {
+    const check = await loadIsClientIpBlocked("::ffff:88.97.223.158");
+    expect(check("88.97.223.158")).toBe(true);
+  });
+
+  it("matches IPv6-mapped IPv4 client against an IPv4 CIDR entry", async () => {
+    const check = await loadIsClientIpBlocked("192.168.1.0/24");
+    expect(check("::ffff:192.168.1.55")).toBe(true);
+  });
+
+  it("silently drops invalid exact-IP entries while keeping valid ones active", async () => {
+    const check = await loadIsClientIpBlocked("not-an-ip,999.999.999.999,88.97.223.158");
+    expect(check("88.97.223.158")).toBe(true);
+    expect(check("1.2.3.4")).toBe(false);
+  });
+});
+
+describe("ipBlocklist middleware — IPv6-mapped IPv4 normalization", () => {
+  beforeEach(() => {
+    process.env.TRUSTED_PROXY_DEPTH = "1";
+  });
+
+  it("blocks an IPv6-mapped IPv4 client when blocklist holds the bare IPv4", async () => {
+    const fn = await loadMiddlewareWithEnv("88.97.223.158");
+    const app = makeApp(fn);
+    const res = await app.request(makeRequest("::ffff:88.97.223.158"));
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks a bare IPv4 client when blocklist holds the IPv6-mapped form", async () => {
+    const fn = await loadMiddlewareWithEnv("::ffff:88.97.223.158");
+    const app = makeApp(fn);
+    const res = await app.request(makeRequest("88.97.223.158"));
+    expect(res.status).toBe(403);
+  });
 });


### PR DESCRIPTION
## Summary

The IP blocklist normalized incoming client IPs (stripping the `::ffff:` IPv6-mapped IPv4 prefix) but stored env-supplied entries raw, creating asymmetric matching. An operator entry of `::ffff:1.2.3.4` would never match a client connecting as `1.2.3.4` once normalized. Exact-IP entries were also accepted without any validation, unlike CIDR entries which are validated via `ipToInt()`.

This change normalizes and validates exact-IP entries at parse time using the same `ipToInt()` check already applied to CIDR entries. Invalid entries are dropped with the existing `Invalid IP blocklist entry dropped` warning instead of being silently inert. The standalone `isClientIpBlocked()` helper used by the WebSocket upgrade path also normalizes its input so it stays consistent with the Hono middleware path.

### Behavioral changes
- `IP_BLOCKLIST=::ffff:1.2.3.4` now correctly blocks a client connecting as `1.2.3.4` (and vice versa).
- `IP_BLOCKLIST=not-an-ip,999.999.999.999` no longer silently accepts garbage entries — they are dropped at parse time with a warning, while valid entries in the same list continue to work.
- No change to CIDR parsing, proxy-depth handling, or fail-closed behavior when the client IP is undeterminable.

## Test plan

- [x] New unit tests for both directions of the IPv6-mapped/bare-IPv4 asymmetry (middleware path and `isClientIpBlocked` path)
- [x] New unit test for IPv6-mapped client against an IPv4 `/24` CIDR entry
- [x] New unit test confirming malformed exact entries are dropped while valid ones in the same list still block
- [x] Full file suite passes locally (`vitest run tests/middleware/ip-blocklist.test.ts` — 20/20)
- [x] `tsc --noEmit` clean
- [x] No regressions in the rest of the suite (the one pre-existing failure in `tests/routes/prices.test.ts` reproduces on `main` and is unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IP blocklist to properly normalize IPv6-mapped IPv4 addresses, ensuring they match corresponding IPv4 blocklist entries
  * Invalid or malformed IP entries in blocklists are now safely ignored without breaking valid entries

* **Tests**
  * Expanded test coverage for IP normalization and validation across various address formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->