### PR TITLE
fix(oracle-router): serve stale cache as fallback on upstream failure

### DIFF
--- a/src/routes/oracle-router.ts
+++ b/src/routes/oracle-router.ts
@@ -8,6 +8,10 @@ const logger = createLogger("api:oracle-router");
 // Simple in-memory cache: mint → { result, expiresAt }
 const cache = new Map<string, { result: PriceRouterResult; expiresAt: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// How long an entry past its TTL may still be served as a stale-while-error
+// fallback when the upstream oracle is unreachable. Bounded so we never serve
+// dangerously-old prices, but generous enough to ride out a transient outage.
+const MAX_STALE_AGE_MS = 15 * 60 * 1000; // 15 minutes past expiry
 const MAX_CACHE_SIZE = 500;
 
 export function oracleRouterRoutes(): Hono {
@@ -28,15 +32,19 @@ export function oracleRouterRoutes(): Hono {
       return c.json({ error: "Invalid mint address" }, 400);
     }
 
-    // Evict expired entries on every read
+    // Evict entries only once they are beyond the stale-fallback window so
+    // expired-but-still-usable entries survive long enough to back up the
+    // catch path below if the upstream oracle is down.
     const now = Date.now();
     for (const [key, entry] of cache) {
-      if (now >= entry.expiresAt) cache.delete(key);
+      if (now >= entry.expiresAt + MAX_STALE_AGE_MS) cache.delete(key);
     }
 
-    // Check cache — promote to most-recently-used on hit
+    // Capture once: used both for the fresh-cache fast path and as a
+    // potential stale fallback in the catch block.
     const cached = cache.get(mint);
     if (cached && now < cached.expiresAt) {
+      // Fresh hit — promote to most-recently-used and return.
       cache.delete(mint);
       cache.set(mint, cached);
       return c.json({ ...cached.result, cached: true });
@@ -57,6 +65,18 @@ export function oracleRouterRoutes(): Hono {
     } catch (err: any) {
       const detail = err instanceof Error ? err.message : String(err);
       logger.error("Oracle resolve error", { detail, path: c.req.path });
+
+      // Stale-while-error fallback: if we have an expired entry that is still
+      // within MAX_STALE_AGE_MS, serve it with stale: true so consumers know
+      // the data is degraded. Otherwise fall through to the original 500.
+      if (cached && Date.now() < cached.expiresAt + MAX_STALE_AGE_MS) {
+        logger.warn("Serving stale oracle cache after upstream error", {
+          mint,
+          stalenessMs: Date.now() - cached.expiresAt,
+        });
+        return c.json({ ...cached.result, cached: true, stale: true });
+      }
+
       return c.json({ error: "Failed to resolve oracle sources" }, 500);
     }
   });

--- a/tests/routes/oracle-router.test.ts
+++ b/tests/routes/oracle-router.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+// Mock @percolatorct/sdk so we control resolvePrice
+vi.mock("@percolatorct/sdk", () => ({
+  resolvePrice: vi.fn(),
+}));
+
+// Mock @percolator/shared (only createLogger is used by oracle-router)
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+// Mock PublicKey to accept any non-empty string so tests don't need real base58
+vi.mock("@solana/web3.js", () => ({
+  PublicKey: class {
+    constructor(s: string) {
+      if (!s) throw new Error("invalid");
+    }
+  },
+}));
+
+const FRESH_RESULT = {
+  mint: "TEST_MINT",
+  sources: [{ name: "pyth", price: 100 }],
+  primary: "pyth",
+} as any;
+
+// Re-import the module fresh per test so the in-memory cache is empty.
+async function loadApp() {
+  vi.resetModules();
+  const sdk = await import("@percolatorct/sdk");
+  const { oracleRouterRoutes } = await import("../../src/routes/oracle-router.js");
+  const app = new Hono();
+  app.route("/", oracleRouterRoutes());
+  return { app, resolvePrice: vi.mocked(sdk.resolvePrice) };
+}
+
+function makeRequest(mint: string) {
+  return new Request(`http://localhost/oracle/resolve/${mint}`);
+}
+
+describe("oracle-router stale-while-error fallback", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns fresh data on a successful resolve", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ...FRESH_RESULT, cached: false });
+    expect(body.stale).toBeUndefined();
+  });
+
+  it("returns 500 when resolvePrice fails and the cache is empty", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice.mockRejectedValueOnce(new Error("oracle down"));
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to resolve oracle sources");
+  });
+
+  it("falls back to stale cached data when resolvePrice fails within the stale window", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    // First call: success — populates the cache.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+    const ok = await app.request(makeRequest("TEST_MINT"));
+    expect(ok.status).toBe(200);
+
+    // Advance past the 5min TTL but stay within the 15min stale window.
+    vi.setSystemTime(new Date("2025-01-01T00:10:00Z"));
+    resolvePrice.mockRejectedValueOnce(new Error("oracle down"));
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ...FRESH_RESULT, cached: true, stale: true });
+  });
+
+  it("returns 500 when the stale entry is older than MAX_STALE_AGE_MS", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+    const ok = await app.request(makeRequest("TEST_MINT"));
+    expect(ok.status).toBe(200);
+
+    // Advance well past TTL + MAX_STALE_AGE (5 + 15 = 20 minutes).
+    vi.setSystemTime(new Date("2025-01-01T00:30:00Z"));
+    resolvePrice.mockRejectedValueOnce(new Error("oracle down"));
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(500);
+  });
+
+  it("prefers a fresh resolve over a stale cache entry", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+    await app.request(makeRequest("TEST_MINT"));
+
+    // Advance past TTL but the next resolve succeeds — should NOT mark stale.
+    vi.setSystemTime(new Date("2025-01-01T00:10:00Z"));
+    const NEW_RESULT = { ...FRESH_RESULT, sources: [{ name: "pyth", price: 200 }] };
+    resolvePrice.mockResolvedValueOnce(NEW_RESULT);
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ...NEW_RESULT, cached: false });
+    expect(body.stale).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`/oracle/resolve/:mint` returned HTTP 500 on every `resolvePrice()` failure (timeout, RPC error, network blip), even though a recently-expired cache entry might still be a perfectly usable degraded answer. The in-memory cache was also being purged of expired entries on every read, so no stale data was ever available as a fallback.

This change:

- Introduces `MAX_STALE_AGE_MS = 15 * 60 * 1000` (15 minutes past TTL) and only evicts cache entries once they are beyond *both* the TTL and the stale window.
- Adds a stale-while-error fallback in the catch block: if a previously-cached entry is within the stale window, return it as HTTP 200 with `stale: true` so consumers can tell the data is degraded.
- Falls through to the original HTTP 500 only when no usable stale entry exists.
- Logs a warning whenever stale data is served, including the staleness in ms, so operators retain visibility into upstream outages.

The 15-minute stale ceiling is intentionally conservative for price data — long enough to absorb a transient oracle outage, short enough that we never hand back dangerously-old prices. The fast path for fresh cache hits and the success path are unchanged.

## Test plan

- [x] New `tests/routes/oracle-router.test.ts` covering:
  - Fresh data on a successful resolve (no `stale` flag)
  - HTTP 500 when `resolvePrice` fails and the cache is empty
  - Stale fallback served (with `stale: true`) when a failure occurs within `MAX_STALE_AGE_MS`
  - HTTP 500 once the stale entry is past `MAX_STALE_AGE_MS`
  - A successful fresh resolve takes precedence over a stale cache entry
- [x] Full test suite passes locally (199/200 — the one failure in `tests/routes/prices.test.ts` reproduces on `main` and is unrelated to this change)
- [x] `tsc --noEmit` clean