### PR TITLE
fix(oracle-router): coalesce concurrent requests for the same mint

### DIFF
--- a/src/routes/oracle-router.ts
+++ b/src/routes/oracle-router.ts
@@ -7,6 +7,11 @@ const logger = createLogger("api:oracle-router");
 
 // Simple in-memory cache: mint → { result, expiresAt }
 const cache = new Map<string, { result: PriceRouterResult; expiresAt: number }>();
+// In-flight request coalescing: mint → pending resolvePrice promise. Used to
+// prevent thundering-herd amplification when N concurrent requests miss cache
+// for the same mint — only the first triggers an upstream call; the rest await
+// the same promise.
+const inflight = new Map<string, Promise<PriceRouterResult>>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_CACHE_SIZE = 500;
 
@@ -42,17 +47,32 @@ export function oracleRouterRoutes(): Hono {
       return c.json({ ...cached.result, cached: true });
     }
 
+    // Coalesce concurrent requests for the same mint: if a fetch is already
+    // in flight, await the same promise instead of starting a new one. The
+    // first request writes the cache and clears the inflight entry only after
+    // the cache is populated, so a request arriving immediately afterwards
+    // sees a fresh cache hit.
+    let inFlightPromise = inflight.get(mint);
+    if (!inFlightPromise) {
+      inFlightPromise = resolvePrice(mint, AbortSignal.timeout(10_000))
+        .then((result) => {
+          if (cache.size >= MAX_CACHE_SIZE) {
+            const oldestKey = cache.keys().next().value;
+            if (oldestKey) cache.delete(oldestKey);
+          }
+          cache.set(mint, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+          inflight.delete(mint);
+          return result;
+        })
+        .catch((err) => {
+          inflight.delete(mint);
+          throw err;
+        });
+      inflight.set(mint, inFlightPromise);
+    }
+
     try {
-      const result = await resolvePrice(mint, AbortSignal.timeout(10_000));
-
-      // Cache the result (with max size enforcement)
-      if (cache.size >= MAX_CACHE_SIZE) {
-        // Delete oldest entry
-        const oldestKey = cache.keys().next().value;
-        if (oldestKey) cache.delete(oldestKey);
-      }
-      cache.set(mint, { result, expiresAt: Date.now() + CACHE_TTL_MS });
-
+      const result = await inFlightPromise;
       return c.json({ ...result, cached: false });
     } catch (err: any) {
       const detail = err instanceof Error ? err.message : String(err);

--- a/tests/routes/oracle-router.test.ts
+++ b/tests/routes/oracle-router.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+// Mock @percolatorct/sdk so we control resolvePrice
+vi.mock("@percolatorct/sdk", () => ({
+  resolvePrice: vi.fn(),
+}));
+
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+// Mock PublicKey to accept any non-empty string so tests don't need real base58
+vi.mock("@solana/web3.js", () => ({
+  PublicKey: class {
+    constructor(s: string) {
+      if (!s) throw new Error("invalid");
+    }
+  },
+}));
+
+const FRESH_RESULT = {
+  mint: "TEST_MINT",
+  sources: [{ name: "pyth", price: 100 }],
+  primary: "pyth",
+} as any;
+
+// Re-import the module fresh per test so the in-memory cache and inflight map are empty.
+async function loadApp() {
+  vi.resetModules();
+  const sdk = await import("@percolatorct/sdk");
+  const { oracleRouterRoutes } = await import("../../src/routes/oracle-router.js");
+  const app = new Hono();
+  app.route("/", oracleRouterRoutes());
+  return { app, resolvePrice: vi.mocked(sdk.resolvePrice) };
+}
+
+function makeRequest(mint: string) {
+  return new Request(`http://localhost/oracle/resolve/${mint}`);
+}
+
+describe("oracle-router in-flight request dedup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("coalesces N concurrent requests for the same mint into a single resolvePrice call", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    // resolvePrice is slow — gives the test time to fire all 10 requests
+    // before the first call settles.
+    let release: (v: any) => void = () => {};
+    const slow = new Promise((r) => {
+      release = r;
+    });
+    resolvePrice.mockImplementation(() => slow as any);
+
+    // Fire 10 concurrent requests for the same uncached mint.
+    const inflight = Array.from({ length: 10 }, () => app.request(makeRequest("TEST_MINT")));
+
+    // Let microtasks settle so all 10 handlers reach the inflight check.
+    await new Promise((r) => setImmediate(r));
+
+    // Only ONE upstream call should have been made.
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+
+    // Release the upstream and let everything settle.
+    release(FRESH_RESULT);
+    const responses = await Promise.all(inflight);
+
+    // All 10 should succeed with the same data.
+    for (const res of responses) {
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({ ...FRESH_RESULT, cached: false });
+    }
+
+    // Still only one upstream call after settlement.
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not coalesce requests for different mints", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice.mockResolvedValue(FRESH_RESULT);
+
+    await Promise.all([
+      app.request(makeRequest("MINT_A")),
+      app.request(makeRequest("MINT_B")),
+      app.request(makeRequest("MINT_C")),
+    ]);
+
+    expect(resolvePrice).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears the in-flight entry after success so a later request hits cache (no second upstream call)", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+
+    const first = await app.request(makeRequest("TEST_MINT"));
+    expect(first.status).toBe(200);
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+
+    // Subsequent request should hit the cache, not the upstream.
+    const second = await app.request(makeRequest("TEST_MINT"));
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.cached).toBe(true);
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight entry after failure so a retry triggers a fresh upstream call", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice
+      .mockRejectedValueOnce(new Error("oracle down"))
+      .mockResolvedValueOnce(FRESH_RESULT);
+
+    const first = await app.request(makeRequest("TEST_MINT"));
+    expect(first.status).toBe(500);
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+
+    // Retry should not be deduped against the failed promise — it should
+    // trigger a new upstream call.
+    const second = await app.request(makeRequest("TEST_MINT"));
+    expect(second.status).toBe(200);
+    expect(resolvePrice).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates upstream errors to all concurrent waiters", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    let reject: (e: any) => void = () => {};
+    const slow = new Promise((_, rej) => {
+      reject = rej;
+    });
+    resolvePrice.mockImplementation(() => slow as any);
+
+    const inflight = Array.from({ length: 5 }, () => app.request(makeRequest("TEST_MINT")));
+    await new Promise((r) => setImmediate(r));
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+
+    reject(new Error("oracle down"));
+    const responses = await Promise.all(inflight);
+    for (const res of responses) {
+      expect(res.status).toBe(500);
+    }
+    expect(resolvePrice).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

`/oracle/resolve/:mint` had no in-flight request deduplication. When N concurrent requests hit the route with no cached value, each handler independently called `resolvePrice()` — causing N-fold thundering-herd amplification on the upstream oracle. Under a spike for a hot token this would burn quota and pile redundant load onto Pyth / downstream price sources, with zero benefit (all N callers get the same data).

This change adds a module-scoped `inflight` Map keyed by mint:

- The first request to miss cache initiates `resolvePrice()` and registers the pending promise.
- Subsequent concurrent requests for the same mint `await` the same promise instead of starting a new fetch.
- The cache write and inflight cleanup are performed inside the promise's `.then` chain, so the inflight entry is only cleared **after** the cache has been populated. This guarantees that a request arriving immediately after settlement sees a fresh cache hit rather than spawning a redundant fetch in the gap.
- On failure, the inflight entry is cleared in the chained `.catch` (and the error is rethrown), so a retry triggers a fresh upstream call rather than getting stuck on a poisoned slot.

The cache fast-path, error handling, response shape, and `cached: false` flag are all unchanged for non-coalesced traffic.

## Test plan

New tests in `tests/routes/oracle-router.test.ts`:

- [x] **10 concurrent requests for the same mint** result in exactly **1** upstream `resolvePrice()` call, and all 10 responses contain the same payload.
- [x] Concurrent requests for **different** mints are **not** coalesced.
- [x] After settlement, a follow-up request hits the cache (no new upstream call) — proving the inflight entry is cleared *after* the cache is written.
- [x] After a **failed** upstream call, a retry triggers a **fresh** upstream call (no poisoned inflight slot).
- [x] Upstream errors propagate to all concurrent waiters.
- [x] Full suite passes locally (193/194 — the one pre-existing failure in `tests/routes/prices.test.ts` reproduces on `main` and is unrelated).
- [x] `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Performance Improvements**
* Optimized price resolution queries through intelligent caching and request coalescing. Multiple concurrent requests for the same asset now share a single upstream call, reducing load and improving response times.

**Tests**
* Added comprehensive test coverage for oracle routing functionality, including concurrent request handling, error scenarios, and cache validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->