### PR TITLE
fix(db-cache-fallback): make return type honest with discriminated success

### DIFF
--- a/src/middleware/db-cache-fallback.ts
+++ b/src/middleware/db-cache-fallback.ts
@@ -23,19 +23,36 @@ const MAX_STALE_AGE_MS = 60 * 60 * 1000;
 const MAX_DB_CACHE_ENTRIES = 200;
 
 /**
+ * Discriminated success result returned by withDbCacheFallback. Callers
+ * narrow against `instanceof Response` to handle the error path; on the
+ * success path they read `result.data`. The `stale` flag distinguishes
+ * fresh query data from cached fallback data so callers can react if they
+ * need to (e.g. additional logging, payload annotation). The HTTP staleness
+ * headers (X-Cache-Status, X-Cache-Age, Warning) are still set on the Hono
+ * context regardless, so they reach the client through the caller's
+ * subsequent c.json() response.
+ */
+export interface DbCacheResult<T> {
+  ok: true;
+  data: T;
+  stale: boolean;
+}
+
+/**
  * Execute a database query with cache fallback.
  * If the query fails, return cached data if available (even if stale).
- * 
+ *
  * @param cacheKey - Unique key for caching this query
  * @param queryFn - Async function that performs the DB query
- * @param c - Hono context (for error responses)
- * @returns Query result or cached data
+ * @param c - Hono context (for error responses and staleness headers)
+ * @returns A `DbCacheResult<T>` on success/stale-fallback, or a `Response`
+ *          (HTTP 503) when both the query failed and no usable cache exists.
  */
 export async function withDbCacheFallback<T>(
   cacheKey: string,
   queryFn: () => Promise<T>,
   c: Context
-): Promise<T | Response> {
+): Promise<DbCacheResult<T> | Response> {
   try {
     // Try the query
     const result = await queryFn();
@@ -52,8 +69,8 @@ export async function withDbCacheFallback<T>(
       data: result,
       timestamp: Date.now(),
     });
-    
-    return result;
+
+    return { ok: true, data: result, stale: false };
   } catch (err) {
     logger.error("DB query failed, checking cache", {
       error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120),
@@ -78,7 +95,11 @@ export async function withDbCacheFallback<T>(
         c.header("X-Cache-Status", "stale-fallback");
         c.header("X-Cache-Age", String(Math.floor(age / 1000)));
         c.header("Warning", `110 - "Response is Stale (${ageMinutes}m old)"`);
-        return cached.data as T;
+        // The dbCache stores `unknown` since it spans multiple call sites with
+        // different T parameters. The cast is contained here: every caller
+        // owns its own cacheKey namespace, so the runtime type is guaranteed
+        // to match the T the caller asked for.
+        return { ok: true, data: cached.data as T, stale: true };
       } else {
         logger.error("Cached data too old, cannot serve", {
           cacheKey,

--- a/src/routes/funding.ts
+++ b/src/routes/funding.ts
@@ -88,10 +88,13 @@ export function fundingRoutes(): Hono {
       c
     );
 
-    // withDbCacheFallback returns a Response on failure (503 with stale data or error)
+    // withDbCacheFallback returns a Response on failure (503 when both the
+    // query failed and no usable cache exists). On success — fresh or stale
+    // fallback — it returns a DbCacheResult; staleness HTTP headers are
+    // already set on the context by the middleware.
     if (result instanceof Response) return result;
 
-    return c.json(result);
+    return c.json(result.data);
   });
 
   /**

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -70,12 +70,14 @@ export function marketRoutes(): Hono {
       c
     );
     
-    // If result is a Response (error case), return it directly
+    // If result is a Response (error case — DB failed AND no usable cache),
+    // return it directly. Otherwise unwrap the DbCacheResult; staleness
+    // headers are already set on the context by the middleware.
     if (result instanceof Response) {
       return result;
     }
-    
-    return c.json({ markets: result });
+
+    return c.json({ markets: result.data });
   });
 
   // GET /markets/stats — all market stats from DB (filtered by network)

--- a/tests/middleware/db-cache-fallback.test.ts
+++ b/tests/middleware/db-cache-fallback.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  truncateErrorMessage: vi.fn((s: string) => s),
+}));
+
+import { withDbCacheFallback, clearDbCache } from "../../src/middleware/db-cache-fallback.js";
+
+function makeApp(handler: (c: any) => Promise<Response>) {
+  const app = new Hono();
+  app.get("/test", handler);
+  return app;
+}
+
+describe("withDbCacheFallback", () => {
+  beforeEach(() => {
+    clearDbCache();
+  });
+
+  it("returns DbCacheResult on success with stale=false and ok=true", async () => {
+    const app = makeApp(async (c) => {
+      const result = await withDbCacheFallback(
+        "test:success",
+        async () => ({ rows: [1, 2, 3] }),
+        c,
+      );
+      if (result instanceof Response) return result;
+      expect(result.ok).toBe(true);
+      expect(result.stale).toBe(false);
+      return c.json(result.data);
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ rows: [1, 2, 3] });
+  });
+
+  it("returns a 503 Response when the query fails and the cache is empty", async () => {
+    const app = makeApp(async (c) => {
+      const result = await withDbCacheFallback(
+        "test:no-cache",
+        async () => {
+          throw new Error("DB down");
+        },
+        c,
+      );
+      if (result instanceof Response) return result;
+      return c.json(result.data);
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("Database temporarily unavailable");
+  });
+
+  it("returns stale cached data with stale=true on failure within MAX_STALE_AGE_MS", async () => {
+    // First call: succeeds and seeds the cache.
+    const seedApp = makeApp(async (c) => {
+      const result = await withDbCacheFallback(
+        "test:stale",
+        async () => ({ value: "fresh" }),
+        c,
+      );
+      if (result instanceof Response) return result;
+      return c.json(result.data);
+    });
+    const seed = await seedApp.request("/test");
+    expect(seed.status).toBe(200);
+
+    // Second call: query throws — middleware should serve the stale entry.
+    let observedStale: boolean | undefined;
+    const fallbackApp = makeApp(async (c) => {
+      const result = await withDbCacheFallback(
+        "test:stale",
+        async () => {
+          throw new Error("DB down");
+        },
+        c,
+      );
+      if (result instanceof Response) return result;
+      observedStale = result.stale;
+      return c.json(result.data);
+    });
+
+    const res = await fallbackApp.request("/test");
+    expect(res.status).toBe(200);
+    expect(observedStale).toBe(true);
+    expect(await res.json()).toEqual({ value: "fresh" });
+    // Headers set by the middleware persist on the context and reach the client.
+    expect(res.headers.get("X-Cache-Status")).toBe("stale-fallback");
+    expect(res.headers.get("Warning")).toMatch(/^110 - "Response is Stale/);
+  });
+});


### PR DESCRIPTION
## Summary

`withDbCacheFallback` declared a return type of `Promise<T | Response>` but the stale-fallback path returned bare `T`, not a `Response`. Callers (`markets.ts`, `funding.ts`) used `instanceof Response` to discriminate the error path, which worked at runtime, but the contract was a lie and the stale-vs-fresh distinction was invisible at the type level. The path also relied on an unsafe `cached.data as T` cast that bypassed the fact that the cache stores `unknown`.

This change replaces the success leg of the union with a small `DbCacheResult<T>` shape:

```ts
interface DbCacheResult<T> {
  ok: true;
  data: T;
  stale: boolean;
}
```

After the change:

- **The return type matches reality.** Success and stale-fallback paths return the wrapper; the no-cache error path still returns a Hono `Response` (HTTP 503 with the existing error body — unchanged for clients).
- **The `as T` cast is contained.** It now sits at the single assembly point inside the middleware, with a comment explaining the per-cache-key namespacing invariant that justifies it (each caller owns its own cache-key namespace, so the runtime type matches the requested `T`).
- **The HTTP staleness headers** (`X-Cache-Status`, `X-Cache-Age`, `Warning`) continue to flow through to the client unchanged. They are set on the Hono context inside the middleware and the caller's subsequent `c.json()` propagates them — the existing behavior is preserved exactly. A new test asserts this end-to-end.
- **Callers gain access to `result.stale`** if they ever want to react to staleness in code (annotate the payload, increment a metric, etc.). Today they don't, but the option is there.

The two existing callers ([src/routes/markets.ts](src/routes/markets.ts) and [src/routes/funding.ts](src/routes/funding.ts)) are updated to read `result.data` after the `Response` narrow. The shape of the JSON they emit is unchanged.

## Test plan

New `tests/middleware/db-cache-fallback.test.ts`:

- [x] Success path returns `DbCacheResult` with `ok: true`, `stale: false`, correct data
- [x] Empty-cache + query failure returns a `Response` with HTTP 503 and the existing error body
- [x] Stale fallback returns `DbCacheResult` with `stale: true` and the cached payload
- [x] Stale fallback **propagates `X-Cache-Status: stale-fallback` and `Warning: 110 - "Response is Stale ..."` headers** to the client through the caller's `c.json()` (regression guard for the runtime header behavior)

Other:

- [x] Existing `markets.test.ts` and `funding.test.ts` integration tests still pass against the updated callers
- [x] Full suite passes locally (191/192 — the one failure in `tests/routes/prices.test.ts` reproduces on `main` and is unrelated)
- [x] `tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Database caching now indicates when served data is stale through response headers and metadata.
  * Enhanced fallback mechanism provides visibility into cache status and data freshness.
  * Response headers show cache status indicators when fallback occurs.

* **Tests**
  * Added comprehensive test suite for cache fallback scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->