### PR TITLE
fix(index): validate API_AUTH_KEY at startup in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,27 @@ if (!process.env.SUPABASE_SERVICE_KEY) {
   process.exit(1);
 }
 
+// In production, API_AUTH_KEY must be configured. Treat empty / whitespace-only
+// as not configured: the runtime check in src/middleware/auth.ts uses `!apiAuthKey`
+// which would falsely accept "   " as a key. Catching this at startup turns a
+// silent fail-late misconfig (HTTP 500 on first protected request) into a hard
+// boot failure that deploy pipelines and health checks will surface immediately.
+if (process.env.NODE_ENV === "production" && !process.env.API_AUTH_KEY?.trim()) {
+  logger.error(
+    "API_AUTH_KEY environment variable is required in production and cannot be empty or whitespace",
+  );
+  process.exit(1);
+}
+
+// In non-production, log a clear warning if auth is disabled. This catches the
+// common "I forgot to set NODE_ENV=production" mistake before the misconfigured
+// service is exposed to real traffic.
+if (process.env.NODE_ENV !== "production" && !process.env.API_AUTH_KEY?.trim()) {
+  logger.warn(
+    "API_AUTH_KEY is not set — API authentication is disabled (non-production mode)",
+  );
+}
+
 logger.info("CORS allowed origins", { origins: allowedOrigins });
 const wildcardOrigins = allowedOrigins.filter(o => o.startsWith("https://*."));
 if (wildcardOrigins.length > 0) {


### PR DESCRIPTION
## Summary

`src/index.ts` validates `CORS_ORIGINS`, `SUPABASE_URL`, and `SUPABASE_SERVICE_KEY` at boot with `process.exit(1)` on missing values, but never validated `API_AUTH_KEY`. The auth middleware in [src/middleware/auth.ts](src/middleware/auth.ts) does catch a missing key at request time in production (returning HTTP 500 with `"Server misconfigured — auth key not set"`), but that is fail-late:

- The misconfigured process boots successfully.
- `/health` has no auth and returns 200, so deploy pipelines and load balancers think the service is ready.
- Only once a real protected request arrives does the misconfiguration surface, as a 500.

This change adds a production-only startup check that mirrors the existing `CORS_ORIGINS` pattern. Two notes:

- **Whitespace handling.** The check uses `!process.env.API_AUTH_KEY?.trim()` so empty string and whitespace-only values are treated as not configured. The runtime check in `auth.ts` uses `!apiAuthKey`, which would otherwise falsely accept `"   "` as a real key.
- **Non-production warning.** An additional `logger.warn(...)` fires when `API_AUTH_KEY` is unset and `NODE_ENV !== "production"`, so the common "I forgot to set `NODE_ENV=production`" mistake is visible at boot rather than only at the first auth failure.

The runtime check in `src/middleware/auth.ts` is left in place as defense in depth.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full test suite passes (188/189 — the one failure in `tests/routes/prices.test.ts` reproduces on `main` and is unrelated)
- [x] No tests import `src/index.ts` (it has top-level `process.exit` side effects), so the new validation block follows the same untested pattern as the existing CORS / Supabase checks. The new logic uses the same idiom that already runs in production daily for `CORS_ORIGINS`.

## Manual verification

After this change, a production deploy with `API_AUTH_KEY` unset (or set to `""` / `"   "`) will fail at boot with:

```
[api] error: API_AUTH_KEY environment variable is required in production and cannot be empty or whitespace
```

and exit code `1`, instead of silently accepting traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API authentication key validation at startup: in production, the app now fails with a clear error message if the key is missing or invalid; in development, warnings indicate when authentication is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->