### PR TITLE
fix(adl): promote cached entries on hit so eviction is LRU not FIFO

### DIFF
--- a/src/routes/adl.ts
+++ b/src/routes/adl.ts
@@ -165,6 +165,11 @@ export function adlRoutes(): Hono {
     // Check cache to avoid redundant expensive RPC calls
     const cached = adlCache.get(slab);
     if (cached && Date.now() - cached.fetchedAt < ADL_CACHE_TTL_MS) {
+      // Promote to most-recently-used so the FIFO-by-insertion eviction
+      // at lines below behaves as LRU. Without this, hot keys inserted
+      // early get evicted while cold keys inserted later survive.
+      adlCache.delete(slab);
+      adlCache.set(slab, cached);
       return c.json(cached.data, 200, { "X-Cache": "HIT" });
     }
 


### PR DESCRIPTION
## Summary
- The \`/adl/:slab\` handler used an in-memory cache with capacity-based eviction via \`adlCache.keys().next().value\`, which deletes the oldest *insertion*. Cache hits did not reposition the entry, so a hot slab inserted early would be evicted before cold slabs inserted later.
- Each cache miss is expensive (Solana RPC \`fetchSlab\` + full account parsing + ranking), so hot keys evicted under capacity pressure caused redundant RPC load and user-visible latency.
- Adds the same promotion-on-hit pattern already used in \`src/routes/oracle-router.ts\` (delete + reinsert before returning the cached payload). The eviction logic at the bottom of the handler is unchanged — it now effectively evicts the least-recently-used entry because the Map's iteration order tracks recency.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] Full test suite: 188/189 passing (the 1 failure is a pre-existing \`tests/routes/prices.test.ts\` issue on \`main\`, unrelated)