### PR TITLE
fix: add RPC timeout to fetchSlab/getSlot to prevent indefinite hangs

### DIFF
--- a/src/routes/adl.ts
+++ b/src/routes/adl.ts
@@ -50,6 +50,7 @@ import {
   createLogger,
   sanitizeSlabAddress,
 } from "@percolator/shared";
+import { withRpcTimeout, RpcTimeoutError } from "../utils/rpc-timeout.js";
 import { isBlockedSlab } from "../middleware/validateSlab.js";
 
 const logger = createLogger("api:adl");
@@ -173,8 +174,15 @@ export function adlRoutes(): Hono {
     const connection = getConnection();
     let data: Uint8Array;
     try {
-      data = await fetchSlab(connection, new PublicKey(slab));
+      data = await withRpcTimeout(
+        fetchSlab(connection, new PublicKey(slab)),
+        `fetchSlab(${slab})`,
+      );
     } catch (err) {
+      if (err instanceof RpcTimeoutError) {
+        logger.warn("RPC timeout fetching slab for ADL", { slab, timeoutMs: err.timeoutMs });
+        return c.json({ error: "Upstream RPC timeout", slab }, 504);
+      }
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("not found")) {
         return c.json({ error: "Slab account not found", slab }, 404);

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getConnection, getSupabase, createLogger, truncateErrorMessage } from "@percolator/shared";
+import { withRpcTimeout, HEALTH_RPC_TIMEOUT_MS } from "../utils/rpc-timeout.js";
 import { getWebSocketMetrics } from "./ws.js";
 import { requireApiKey } from "../middleware/auth.js";
 
@@ -26,7 +27,7 @@ export function healthRoutes(): Hono {
     
     // Check RPC connectivity
     try {
-      await getConnection().getSlot();
+      await withRpcTimeout(getConnection().getSlot(), "healthcheck:getSlot", HEALTH_RPC_TIMEOUT_MS);
       checks.rpc = true;
     } catch (err) {
       logger.error("RPC check failed", { error: truncateErrorMessage(err instanceof Error ? err.message : err, 120) });

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -5,6 +5,7 @@ import { cacheMiddleware } from "../middleware/cache.js";
 import { withDbCacheFallback } from "../middleware/db-cache-fallback.js";
 import { fetchSlab, parseHeader, parseConfig, parseEngine } from "@percolator/sdk";
 import { getConnection, getSupabase, getNetwork, createLogger, sanitizeSlabAddress, truncateErrorMessage } from "@percolator/shared";
+import { withRpcTimeout, RpcTimeoutError } from "../utils/rpc-timeout.js";
 
 const logger = createLogger("api:markets");
 
@@ -123,7 +124,10 @@ export function marketRoutes(): Hono {
     try {
       const connection = getConnection();
       const slabPubkey = new PublicKey(slab);
-      const data = await fetchSlab(connection, slabPubkey);
+      const data = await withRpcTimeout(
+        fetchSlab(connection, slabPubkey),
+        `fetchSlab(${slab})`,
+      );
       const header = parseHeader(data);
       const cfg = parseConfig(data);
       const engine = parseEngine(data);
@@ -150,6 +154,10 @@ export function marketRoutes(): Hono {
         },
       });
     } catch (err) {
+      if (err instanceof RpcTimeoutError) {
+        logger.warn("RPC timeout fetching market", { slab, timeoutMs: err.timeoutMs });
+        return c.json({ error: "Upstream RPC timeout" }, 504);
+      }
       const detail = err instanceof Error ? err.message : "Unknown error";
       const isNotFound = detail.includes("not found") || detail.includes("Account does not exist");
       if (isNotFound) {

--- a/src/utils/rpc-timeout.ts
+++ b/src/utils/rpc-timeout.ts
@@ -1,0 +1,41 @@
+/**
+ * Timeout wrapper for RPC calls that don't accept AbortSignal.
+ *
+ * fetchSlab() and getConnection().getSlot() from the SDK/shared libs take a
+ * Connection object, not an AbortSignal, so AbortSignal.timeout() cannot be
+ * threaded through.  Promise.race is the only viable approach.
+ *
+ * The underlying RPC call is NOT cancelled — Node will GC the dangling promise
+ * once it settles.  This is acceptable because fetchSlab/getSlot are read-only.
+ */
+
+const DEFAULT_RPC_TIMEOUT_MS = 10_000;
+const DEFAULT_HEALTH_RPC_TIMEOUT_MS = 5_000;
+
+export const RPC_TIMEOUT_MS: number =
+  Number(process.env.RPC_TIMEOUT_MS) || DEFAULT_RPC_TIMEOUT_MS;
+
+export const HEALTH_RPC_TIMEOUT_MS: number =
+  Number(process.env.HEALTH_RPC_TIMEOUT_MS) || DEFAULT_HEALTH_RPC_TIMEOUT_MS;
+
+export class RpcTimeoutError extends Error {
+  public readonly timeoutMs: number;
+
+  constructor(operation: string, timeoutMs: number) {
+    super(`RPC timeout: ${operation} did not complete within ${timeoutMs}ms`);
+    this.name = "RpcTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function withRpcTimeout<T>(
+  promise: Promise<T>,
+  operation: string,
+  timeoutMs: number = RPC_TIMEOUT_MS,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new RpcTimeoutError(operation, timeoutMs)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer!));
+}


### PR DESCRIPTION
## Summary

- **Bug**: `fetchSlab()` from `@percolator/sdk` and `getConnection().getSlot()` from `@percolator/shared` have no timeout. If the Solana RPC node is slow or unresponsive, requests to `/markets/:slab`, `/api/adl/rankings`, and `/health` hang indefinitely — tying up server connections with no upper bound.
- **Fix**: Adds a shared `withRpcTimeout()` utility using `Promise.race` that wraps these opaque SDK calls with a configurable deadline.

## Changes

| File | Change |
|------|--------|
| `src/utils/rpc-timeout.ts` | New utility — `withRpcTimeout()`, `RpcTimeoutError` class, env-configurable defaults |
| `src/routes/markets.ts` | Wraps `fetchSlab()` at L126 with 10s timeout, returns 504 on timeout |
| `src/routes/adl.ts` | Wraps `fetchSlab()` at L176 with 10s timeout, returns 504 on timeout |
| `src/routes/health.ts` | Wraps `getSlot()` at L29 with 5s timeout, reports `checks.rpc=false` |

## Design decisions

- **`Promise.race`** (not `AbortSignal`) — `fetchSlab` and `getSlot` don't accept signals
- **10s route / 5s health** — generous enough for normal RPC spikes, prevents indefinite hang
- **`RPC_TIMEOUT_MS` / `HEALTH_RPC_TIMEOUT_MS` env vars** — tunable on Railway without redeploy
- **504 Gateway Timeout** — semantically correct for upstream RPC timeout
- **Custom `RpcTimeoutError`** — enables `instanceof` checks and Sentry grouping

## Test plan

- [x] `tsc --noEmit` passes (zero type errors)
- [x] `vitest run` passes (186/186 tests)
- [ ] Manual: hit `/markets/:slab` with an unreachable RPC to verify 504 response
- [ ] Verify Sentry groups `RpcTimeoutError` separately from generic 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RPC endpoint requests now enforce timeout protection.
  * Requests exceeding the timeout duration return HTTP 504 responses with error details.
  * Timeout durations are configurable per operation type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->