### PR TITLE
docs: add API key auth requirement to /ws/stats in OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -66,8 +66,10 @@ paths:
       tags:
         - WebSocket
       summary: WebSocket connection metrics
-      description: Returns current WebSocket connection counts, throughput, and rate limits
+      description: Returns current WebSocket connection counts, throughput, and rate limits. Requires API key authentication.
       operationId: getWsStats
+      security:
+        - ApiKeyAuth: []
       responses:
         '200':
           description: WebSocket metrics
@@ -86,6 +88,14 @@ paths:
                   maxGlobalConnections: 500
                   maxConnectionsPerSlab: 50
                   maxConnectionsPerIp: 5
+        '401':
+          description: Unauthorized — missing or invalid x-api-key header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Unauthorized: invalid or missing x-api-key"
         '500':
           $ref: '#/components/responses/InternalServerError'
   /health:
@@ -623,6 +633,13 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: API key passed via the x-api-key request header
+
   parameters:
     SlabAddress:
       name: slab


### PR DESCRIPTION
## Summary

- **Issue**: `GET /ws/stats` requires `x-api-key` header via `requireApiKey()` middleware, but the OpenAPI spec had no `security` requirement. Clients following the spec would receive an undocumented 401.
- **Fix**: Adds `securitySchemes` component and `security` + `401` response to the `/ws/stats` operation.

## Changes

- Added `components.securitySchemes.ApiKeyAuth` (apiKey in header, name: `x-api-key`)
- Added `security: [ApiKeyAuth: []]` to `/ws/stats` GET operation
- Added `401` response with example error message
- Updated endpoint description to note auth requirement

## Test plan

- [x] `vitest run` passes (186/186 tests)
- [x] Verified `requireApiKey()` checks `x-api-key` header in `src/middleware/auth.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)