### PR TITLE
docs: add missing ws field to HealthResponse.checks in OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -685,6 +685,9 @@ components:
             rpc:
               type: boolean
               description: Solana RPC connectivity status
+            ws:
+              type: boolean
+              description: WebSocket subsystem status (false when >95% of connection slots used)
         uptime:
           type: integer
           description: Service uptime in seconds


### PR DESCRIPTION
## Summary

- **Issue**: `/health` returns `checks.ws` (boolean) indicating WebSocket subsystem health, but the `HealthResponse` schema only documented `db` and `rpc`. Strict schema validation would flag the undocumented field.
- **Fix**: Adds `ws` boolean property to `HealthResponse.checks` with description.

## Test plan

- [x] `vitest run` passes (186/186 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)