### PR TITLE
docs: fix funding history limit — spec said 1000, code caps at 500

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -468,11 +468,11 @@ paths:
         - $ref: '#/components/parameters/SlabAddress'
         - name: limit
           in: query
-          description: Maximum number of records to return (max 1000)
+          description: Maximum number of records to return (max 500)
           schema:
             type: integer
             default: 100
-            maximum: 1000
+            maximum: 500
         - name: since
           in: query
           description: ISO timestamp to fetch records from


### PR DESCRIPTION
## Summary

- **Issue**: `/funding/{slab}/history` caps results at 500 rows (`funding.ts:346`, PERC-8178), but the OpenAPI spec documented `maximum: 1000`. Clients requesting `?limit=800` would silently receive at most 500 results.
- **Fix**: Updates spec `maximum` from 1000 to 500 and description to match.

## Test plan

- [x] `vitest run` passes (186/186 tests)
- [x] Verified `MAX_ROWS = 500` in `funding.ts:346`

🤖 Generated with [Claude Code](https://claude.com/claude-code)