### PR TITLE
fix: rename SOLANA_RPC_URL to RPC_URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,10 @@ WS_AUTH_REQUIRED=false
 WS_AUTH_SECRET=
 
 # Solana
-SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+# The shared library reads RPC_URL (not SOLANA_RPC_URL).
+# For mainnet: use a paid RPC provider (Helius, Alchemy, etc.) — the public
+# endpoint rate-limits aggressively and is unsuitable for production.
+RPC_URL=https://api.mainnet-beta.solana.com
 
 # Supabase
 SUPABASE_URL=


### PR DESCRIPTION
## Summary

- **Issue**: `.env.example` documented `SOLANA_RPC_URL` but `@percolator/shared` reads `RPC_URL` (in `validation.ts`, `config.ts`, `networkValidation.ts`). `SOLANA_RPC_URL` is referenced nowhere in code. Operators copying the example file would set the wrong env var — silently falling back to devnet in development, or crashing in production with a confusing `"RPC_URL is required"` error.
- **Fix**: Renames the env var in `.env.example` to `RPC_URL` and adds a comment about using a paid RPC for production.

## Changes

- `.env.example`: `SOLANA_RPC_URL` → `RPC_URL` with documentation comment

## Test plan

- [x] `vitest run` passes (186/186 tests)
- [x] Verified `@percolator/shared` reads `RPC_URL` in validation.ts:39, config.ts:24, networkValidation.ts:52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RPC endpoint configuration variable name to `RPC_URL`. Added guidance on distinguishing between production and public mainnet endpoint usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->