### PR TITLE
fix: normalize netLpPosition to netLpPos for API consistency

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -885,7 +885,7 @@ components:
         dailyRatePercent:
           type: number
           description: Daily funding rate as percentage
-        netLpPosition:
+        netLpPos:
           type: string
           description: Net LP position (inventory imbalance)
 
@@ -902,7 +902,7 @@ components:
           type: number
         annualizedPercent:
           type: number
-        netLpPosition:
+        netLpPos:
           type: string
         last24hHistory:
           type: array

--- a/src/routes/funding.ts
+++ b/src/routes/funding.ts
@@ -69,7 +69,7 @@ export function fundingRoutes(): Hono {
         // GH#1459: Filter blocked slabs from the global response.
         // validateSlab middleware only runs on /:slab routes; the global endpoint
         // queries all market_stats rows and previously exposed blocked slabs
-        // (8eFFEFBY, 3bmCyPee, 3YDqCJGz, 3ZKKwsK) with phantom netLpPosition values.
+        // (8eFFEFBY, 3bmCyPee, 3YDqCJGz, 3ZKKwsK) with phantom netLpPos values.
         const markets = (allStats ?? [])
           .filter((stats) => !isBlockedSlab(stats.slab_address))
           .map((stats) => {
@@ -79,7 +79,7 @@ export function fundingRoutes(): Hono {
               currentRateBpsPerSlot: rateBps,
               hourlyRatePercent: Number(((rateBps / 10000.0) * SLOTS_PER_HOUR).toFixed(6)),
               dailyRatePercent: Number(((rateBps / 10000.0) * SLOTS_PER_DAY).toFixed(4)),
-              netLpPosition: stats.net_lp_pos ?? "0",
+              netLpPos: stats.net_lp_pos ?? "0",
             };
           });
 
@@ -105,7 +105,7 @@ export function fundingRoutes(): Hono {
    *   "hourlyRatePercent": 0.42,
    *   "dailyRatePercent": 10.08,
    *   "annualizedPercent": 3679.2,
-   *   "netLpPosition": "1500000",
+   *   "netLpPos": "1500000",
    *   "fundingIndexQpbE6": "123456789",
    *   "lastUpdatedSlot": 123456789,
    *   "last24hHistory": [
@@ -140,7 +140,7 @@ export function fundingRoutes(): Hono {
 
       // Parse current funding data
       const currentRateBpsPerSlot = stats.funding_rate ?? 0;
-      const netLpPosition = stats.net_lp_pos ?? "0";
+      const netLpPos = stats.net_lp_pos ?? "0";
 
       // Calculate rates
       // Solana slots: ~2.5 slots/second = 400ms per slot
@@ -189,7 +189,7 @@ export function fundingRoutes(): Hono {
         hourlyRatePercent: Number(hourlyRatePercent.toFixed(6)),
         dailyRatePercent: Number(dailyRatePercent.toFixed(4)),
         annualizedPercent: Number(annualizedPercent.toFixed(2)),
-        netLpPosition,
+        netLpPos,
         last24hHistory,
         metadata: {
           // GH#1511: Populate symbol and last_price from markets_with_stats.

--- a/tests/routes/funding.test.ts
+++ b/tests/routes/funding.test.ts
@@ -91,7 +91,7 @@ describe("funding routes", () => {
       const data = await res.json();
       expect(data.slabAddress).toBe("11111111111111111111111111111111");
       expect(data.currentRateBpsPerSlot).toBe(10);
-      expect(data.netLpPosition).toBe("1000000");
+      expect(data.netLpPos).toBe("1000000");
       expect(data.last24hHistory).toHaveLength(1);
     });
 


### PR DESCRIPTION
## Summary

- **Issue**: The same logical field (net LP position) used two different JSON names: `netLpPosition` in `/funding/global` and `/funding/:slab` top-level, but `netLpPos` in `/markets`, `/open-interest`, and all funding history arrays. Most notably, a single `/funding/:slab` response contained **both names** — `netLpPosition` at the top level and `netLpPos` inside `last24hHistory` entries.
- **Fix**: Standardizes on `netLpPos` everywhere.

## Why `netLpPos`?

- **6 of 8** existing occurrences already used `netLpPos`
- Matches the DB column name `net_lp_pos` (natural camelCase translation)
- Aligns with the abbreviated convention used throughout the API (`netLpPos`, `lpSumAbs`, etc.)
- Smallest diff — only 2 response fields need changing

## Changes

| File | Change |
|------|--------|
| `src/routes/funding.ts` | `netLpPosition` → `netLpPos` in `/funding/global` (L82) and `/funding/:slab` (L143, L192) responses + comments |
| `openapi.yaml` | Updated `FundingRateSummary` (L888) and `FundingRateDetails` (L905) schemas |
| `tests/routes/funding.test.ts` | Updated assertion (L94) |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` passes (186/186 tests)
- [x] Verified `netLpPos` is now used consistently across all endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)