### PR TITLE
fix(ws): report actually subscribed channels in legacy subscribe response

### DIFF
--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -926,17 +926,24 @@ export function setupWebSocket(server: Server): WebSocketServer {
             message: "Please use channels array. Subscribing to all channels for this slab." 
           }));
           
+          const subscribed: string[] = [];
           for (const channel of channels) {
             if (client.subscriptions.has(channel)) continue;
             if (globalSubscriptionCount >= MAX_GLOBAL_SUBSCRIPTIONS) break;
             if (client.subscriptions.size >= MAX_SUBSCRIPTIONS_PER_CLIENT) break;
-            
+
             client.subscriptions.add(channel);
             globalSubscriptionCount++;
+            subscribed.push(channel);
           }
-          
-          addClientToSlab(client, sanitized);
-          ws.send(JSON.stringify({ type: "subscribed", slabAddress: sanitized, channels }));
+
+          if (subscribed.length > 0) {
+            addClientToSlab(client, sanitized);
+          }
+          ws.send(JSON.stringify({ type: "subscribed", slabAddress: sanitized, channels: subscribed }));
+          if (subscribed.length < channels.length) {
+            ws.send(JSON.stringify({ type: "error", message: "Subscription limit reached — some channels were not subscribed" }));
+          }
         }
         // Handle unsubscribe with channels array
         else if (msg.type === "unsubscribe" && msg.channels && Array.isArray(msg.channels)) {


### PR DESCRIPTION
## Summary

- **Issue**: The legacy WebSocket subscribe handler (single-slab backward compat path) always returned the full 3-channel array (`price`, `trades`, `funding`) in the `subscribed` response, even when `MAX_GLOBAL_SUBSCRIPTIONS` or `MAX_SUBSCRIPTIONS_PER_CLIENT` caused the loop to break early. Clients believed they were fully subscribed but silently missed trade or funding updates — a silent data loss scenario.
- **Fix**: Track actually-subscribed channels in a separate array (mirroring the modern handler's correct pattern) and return only those in the response. Sends an error message when limits cause partial subscription.

## Context

The **modern** subscribe handler (channel-array based) already does this correctly — it builds a `subscribed` accumulator and returns only that. This fix brings the **legacy** handler to parity.

## Changes

- `src/routes/ws.ts`: Legacy subscribe loop now tracks `subscribed[]`, only adds to slab map if >= 1 channel succeeded, returns actual subscriptions, and sends error on partial failure.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` passes (186/186 tests)
- [ ] Manual: connect via legacy subscribe with near-limit global subscriptions, verify response reflects actual state

🤖 Generated with [Claude Code](https://claude.com/claude-code)