### PR TITLE
fix: align price validation ceiling in /funding/:slab with /markets

### DIFF
--- a/src/routes/funding.ts
+++ b/src/routes/funding.ts
@@ -177,8 +177,8 @@ export function fundingRoutes(): Hono {
       }));
 
       // GH#1511: Sanitize last_price from markets_with_stats — same ceiling used
-      // in /api/markets to guard against unscaled admin-set test prices.
-      const MAX_SANE_PRICE_USD = 1_000_000;
+      // in /markets to guard against unscaled admin-set test prices.
+      const MAX_SANE_PRICE_USD = 1_000_000_000;
       const rawLastPrice = Number(stats.last_price ?? 0);
       const sanitizedLastPrice =
         rawLastPrice > 0 && rawLastPrice <= MAX_SANE_PRICE_USD ? rawLastPrice : null;


### PR DESCRIPTION
## Summary

- **Issue**: `/funding/:slab` used `MAX_SANE_PRICE_USD = 1,000,000` ($1M) while `/markets` uses `1,000,000,000` ($1B) for the same `last_price` field from the same `markets_with_stats` view. The comment even claimed "same ceiling used in /markets" which was factually wrong. An asset priced >$1M would show valid in `/markets` but `null` in `/funding/:slab` metadata.
- **Fix**: Aligns to `1,000,000,000` ($1B) to match `/markets`.

## Test plan

- [x] `vitest run` passes (186/186 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)