### PR TITLE
fix(ws): reject tokens with NaN timestamps in verifyWsToken

### DIFF
--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -284,7 +284,8 @@ function verifyWsToken(token: string, expectedSlab?: string): { isValid: boolean
     
     const [slabAddress, timestampStr, signature] = parts;
     const timestamp = parseInt(timestampStr, 10);
-    
+    if (Number.isNaN(timestamp)) return { isValid: false, slabAddress: null };
+
     // Check timestamp is within last 5 minutes and not in the future (30s clock skew tolerance)
     const now = Date.now();
     if (now - timestamp > 5 * 60 * 1000 || timestamp > now + 30_000) {


### PR DESCRIPTION
## Summary

- **Issue**: `parseInt(timestampStr, 10)` returns `NaN` for non-numeric strings. Without a guard, `now - NaN > 300000` evaluates to `false`, allowing the time check to **pass**. While the subsequent HMAC check still prevents forgery (attacker needs the secret), this is a defense-in-depth gap.
- **Fix**: Adds `Number.isNaN(timestamp)` guard immediately after `parseInt`, rejecting malformed timestamps before reaching the time comparison.

## Changes

- `src/routes/ws.ts`: 1 line added after `parseInt` — early return on NaN

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` passes (186/186 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)