### PR TITLE
fix: copy openapi.yaml into Docker production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
+COPY openapi.yaml ./
 RUN chown -R node:node /app
 USER node
 EXPOSE 3001


### PR DESCRIPTION
## Summary

- **Issue**: The Dockerfile never copies `openapi.yaml` into the production image. The `/docs/openapi.yaml` endpoint reads it at runtime via `fs.readFile("/app/openapi.yaml")`, but that file doesn't exist in the container — guaranteed 500 error on the `/docs` endpoint in production.
- **Root cause**: Builder stage only copies `package.json`, lockfiles, `tsconfig.json`, and `src/`. Runner stage only copies `dist/`, `node_modules/`, `package.json`. `tsc` doesn't copy non-TS files. `openapi.yaml` lives at the project root, outside `src/`.
- **Fix**: Add `COPY openapi.yaml ./` to the runner stage (1 line).

## Path trace

```
src/routes/docs.ts:14 → join(__dirname, "..", "..", "openapi.yaml")
At runtime: __dirname = /app/dist/routes/
Resolves to: /app/openapi.yaml ← does not exist without this fix
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` passes (186/186 tests)
- [ ] Docker build: verify `/app/openapi.yaml` exists in final image
- [ ] `curl localhost:3001/docs/openapi.yaml` returns YAML, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)