### PR TITLE
docs: fix README endpoint table — remove non-existent /v1/ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,22 +58,33 @@ pnpm test
 
 ## API Endpoints
 
-| Method | Endpoint               | Description                    |
-|--------|------------------------|--------------------------------|
-| GET    | `/health`              | Health check                   |
-| GET    | `/docs`                | OpenAPI documentation          |
-| GET    | `/v1/markets`          | List all markets               |
-| GET    | `/v1/markets/:address` | Single market details          |
-| GET    | `/v1/prices`           | Current prices                 |
-| GET    | `/v1/prices/history`   | Price history (OHLCV)          |
-| GET    | `/v1/trades`           | Trade history                  |
-| GET    | `/v1/funding`          | Current funding rates          |
-| GET    | `/v1/funding/history`  | Funding rate history           |
-| GET    | `/v1/open-interest`    | Open interest data             |
-| GET    | `/v1/insurance`        | Insurance fund info            |
-| GET    | `/v1/stats`            | Platform statistics            |
-| GET    | `/v1/crank`            | Crank status                   |
-| WS     | `/ws`                  | WebSocket for live updates     |
+| Method | Endpoint                        | Description                    |
+|--------|---------------------------------|--------------------------------|
+| GET    | `/health`                       | Health check                   |
+| GET    | `/docs`                         | OpenAPI documentation          |
+| GET    | `/markets`                      | List all markets               |
+| GET    | `/markets/:slab`                | Single market details (on-chain) |
+| GET    | `/markets/stats`                | All market stats               |
+| GET    | `/markets/:slab/stats`          | Single market stats            |
+| GET    | `/markets/:slab/trades`         | Trade history for a market     |
+| GET    | `/markets/:slab/volume`         | 24h volume for a market        |
+| GET    | `/markets/:slab/prices`         | Price history for a market     |
+| GET    | `/prices/markets`               | Current prices for all markets |
+| GET    | `/prices/:slab`                 | Oracle price history           |
+| GET    | `/trades/recent`                | Recent trades (global)         |
+| GET    | `/funding/global`               | Funding rates for all markets  |
+| GET    | `/funding/:slab`                | Funding rate for a market      |
+| GET    | `/funding/:slab/history`        | Funding rate history           |
+| GET    | `/funding/:slab/historySince`   | Funding history since timestamp |
+| GET    | `/open-interest/:slab`          | Open interest data             |
+| GET    | `/insurance/:slab`              | Insurance fund info            |
+| GET    | `/stats`                        | Platform statistics            |
+| GET    | `/crank/status`                 | Crank status                   |
+| GET    | `/oracle/resolve/:mint`         | Oracle price resolution        |
+| GET    | `/chart/:mint`                  | OHLCV candle data              |
+| GET    | `/api/adl/rankings`             | ADL rankings                   |
+| GET    | `/ws/stats`                     | WebSocket metrics (auth required) |
+| WS     | `/`                             | WebSocket for live updates     |
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- **Issue**: README documented routes with a `/v1/` prefix (`/v1/markets`, `/v1/prices`, etc.) but all actual routes are registered without any version prefix. Clients following the README would get 404s on every endpoint.
- **Fix**: Updates the endpoint table to match actual route registration. Also adds all endpoints that were previously missing from the table.

## Changes

- Removed `/v1/` prefix from all routes (11 entries)
- Added 14 missing endpoints: per-market routes (`/markets/:slab/trades`, `/markets/:slab/volume`, `/markets/:slab/prices`, `/markets/:slab/stats`), oracle, chart, ADL, ws/stats, funding/historySince, trades/recent, prices/markets, prices/:slab, crank/status
- Updated `:address` to `:slab` (matching actual param name)

## Test plan

- [x] `vitest run` passes (186/186 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)