### PR TITLE
fix(open-interest): return OI history in ascending order for charts

### DIFF
--- a/src/routes/open-interest.ts
+++ b/src/routes/open-interest.ts
@@ -77,12 +77,15 @@ export function openInterestRoutes(): Hono {
         }, 404);
       }
 
-      // Fetch historical OI data
+      // Fetch historical OI data in ascending order (oldest→newest) so chart
+      // components can feed the series directly into lightweight-charts setData(),
+      // which requires strictly ascending timestamps.  Previously returned DESC
+      // (newest first) — same issue that was fixed in prices.ts (see GH#xxx).
       const { data: history, error: historyError } = await getSupabase()
         .from("oi_history")
         .select("timestamp, total_oi, net_lp_pos")
         .eq("market_slab", slab)
-        .order("timestamp", { ascending: false })
+        .order("timestamp", { ascending: true })
         .limit(100);
 
       if (historyError) {


### PR DESCRIPTION
## Summary
- The `/open-interest/:slab` endpoint returned `oi_history` rows in **descending** order (newest first). Chart consumers using `lightweight-charts` require strictly ascending timestamps for `setData()`.
- This is the same issue that was previously fixed in `src/routes/prices.ts` (see comment at lines 30-37), where DESC ordering caused `aggregateCandles` to produce DESC-ordered candles and `lightweight-charts` silently failed.
- Switches `.order("timestamp", { ascending: false })` → `{ ascending: true }` so the history array can be fed directly into the chart component without a client-side reversal.

## Test plan
- [x] `npx vitest run tests/routes/open-interest.test.ts` — 16/16 passing
- [x] Full suite: 188/189 passing (the 1 failure is a pre-existing `tests/routes/prices.test.ts` issue on `main`, unrelated)
- [x] `npx tsc --noEmit` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the chronological ordering of historical open interest data to ensure proper visualization in charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->