### PR TITLE
fix(markets): add missing columns to stats endpoints per OpenAPI schema

### DIFF
--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -83,7 +83,7 @@ export function marketRoutes(): Hono {
     try {
       const { data, error } = await getSupabase()
         .from("markets_with_stats")
-        .select("slab_address, total_open_interest, total_accounts, last_crank_slot, last_price, mark_price, index_price, funding_rate, net_lp_pos, updated_at")
+        .select("slab_address, total_open_interest, total_accounts, last_crank_slot, last_price, mark_price, index_price, funding_rate, net_lp_pos, lp_sum_abs, lp_max_abs, insurance_balance, insurance_fee_revenue, volume_24h, updated_at")
         .eq("network", getNetwork())
         .not("slab_address", "is", null);
       if (error) throw error;
@@ -102,7 +102,7 @@ export function marketRoutes(): Hono {
     try {
       const { data, error } = await getSupabase()
         .from("market_stats")
-        .select("slab_address, total_open_interest, total_accounts, last_crank_slot, last_price, mark_price, index_price, funding_rate, net_lp_pos, updated_at")
+        .select("slab_address, total_open_interest, total_accounts, last_crank_slot, last_price, mark_price, index_price, funding_rate, net_lp_pos, lp_sum_abs, lp_max_abs, insurance_balance, insurance_fee_revenue, volume_24h, updated_at")
         .eq("slab_address", slab)
         .single();
       if (error && error.code !== "PGRST116") throw error;


### PR DESCRIPTION
## Summary
- Both `/markets/stats` and `/markets/:slab/stats` selected only 10 columns, but the OpenAPI `MarketStats` schema documents 14 fields.
- Missing columns: `lp_sum_abs`, `lp_max_abs`, `insurance_balance`, `insurance_fee_revenue`, `volume_24h` — all present in the DB (queried successfully by other routes like `insurance.ts`, `open-interest.ts`, `stats.ts`, `trades.ts`) but omitted from the stats endpoint select clauses.
- API consumers relying on the documented schema would receive null/missing values for LP statistics, insurance fund data, and 24h volume.

## Test plan
- [x] `npx vitest run tests/routes/markets.test.ts` — 10/10 passing
- [x] Full suite: 188/189 passing (the 1 failure is a pre-existing `tests/routes/prices.test.ts` issue on `main`, unrelated)
- [x] `npx tsc --noEmit` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market statistics endpoints now return additional data fields including LP position metrics, insurance information, and 24-hour trading volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->