### PR TITLE
fix(startup): use process.exit(1) for NODE_ENV validation, not throw

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ if (!process.env.NODE_ENV || !validNodeEnvs.includes(process.env.NODE_ENV)) {
     nodeEnv: process.env.NODE_ENV ?? "(unset)",
     validOptions: validNodeEnvs.join(", ")
   });
-  throw new Error(`NODE_ENV must be explicitly set. Got: ${process.env.NODE_ENV ?? "(unset)"}. Must be one of: ${validNodeEnvs.join(", ")}`);
+  process.exit(1);
 }
 
 const port = Number(process.env.API_PORT ?? 3001);


### PR DESCRIPTION
## Summary
- NODE_ENV validation at startup used `throw new Error(...)` while every other env-var check in the same file (`SUPABASE_URL`, `SUPABASE_KEY`, `API_AUTH_KEY`, `API_PORT`, DB connectivity) uses `process.exit(1)` after structured logging.
- The `throw` produces an uncaught exception with a noisy stack trace instead of the clean log-and-exit pattern, confusing operators when NODE_ENV is misconfigured.
- 1-line change: `throw new Error(...)` → `process.exit(1)`. The structured error log on the preceding line already captures all diagnostic context.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Full suite: 188/189 passing (the 1 failure is a pre-existing `tests/routes/prices.test.ts` issue on `main`, unrelated)