### PR TITLE
fix(routes): truncate error details in non-production responses

### DIFF
--- a/src/routes/insurance.ts
+++ b/src/routes/insurance.ts
@@ -80,7 +80,7 @@ export function insuranceRoutes(): Hono {
       logger.error("Error fetching insurance data", { slab, error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120) });
       return c.json({ 
         error: "Failed to fetch insurance data",
-        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
+        ...(process.env.NODE_ENV !== "production" && { details: truncateErrorMessage(err instanceof Error ? err.message : String(err), 200) })
       }, 500);
     }
   });

--- a/src/routes/open-interest.ts
+++ b/src/routes/open-interest.ts
@@ -112,7 +112,7 @@ export function openInterestRoutes(): Hono {
       logger.error("Error fetching OI data", { slab, error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120) });
       return c.json({ 
         error: "Failed to fetch open interest data",
-        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
+        ...(process.env.NODE_ENV !== "production" && { details: truncateErrorMessage(err instanceof Error ? err.message : String(err), 200) })
       }, 500);
     }
   });

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -91,7 +91,7 @@ export function statsRoutes(): Hono {
       logger.error("Error fetching platform stats", { error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120) });
       return c.json({ 
         error: "Failed to fetch platform statistics",
-        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
+        ...(process.env.NODE_ENV !== "production" && { details: truncateErrorMessage(err instanceof Error ? err.message : String(err), 200) })
       }, 500);
     }
   });


### PR DESCRIPTION
## Summary
- \`insurance.ts\`, \`open-interest.ts\`, and \`stats.ts\` exposed untruncated error messages in non-production 500 responses via the \`details\` field.
- While gated on \`NODE_ENV !== "production"\`, raw error messages can contain internal file paths, DB connection strings, or stack traces that aid reconnaissance in staging/dev environments shared with external testers.
- Wraps with \`truncateErrorMessage(..., 200)\` to match the pattern already used by \`funding.ts\` and the logger calls in the same catch blocks.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] Full suite: 188/189 passing (the 1 failure is a pre-existing \`tests/routes/prices.test.ts\` issue on \`main\`, unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied consistent error message length limits across three API endpoints (Insurance, Open Interest, and Stats) in non-production environments, ensuring all error details are properly capped and standardized across the platform. This prevents excessively verbose error responses that could otherwise negatively impact client error handling, response readability, and system logging efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->