### PR TITLE
fix(oracle-router): serve stale cache as fallback on upstream failure

### DIFF
--- a/src/routes/oracle-router.ts
+++ b/src/routes/oracle-router.ts
@@ -13,6 +13,10 @@ const cache = new Map<string, { result: PriceRouterResult; expiresAt: number }>(
 // the same promise.
 const inflight = new Map<string, Promise<PriceRouterResult>>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// How long an entry past its TTL may still be served as a stale-while-error
+// fallback when the upstream oracle is unreachable. Bounded so we never serve
+// dangerously-old prices, but generous enough to ride out a transient outage.
+const MAX_STALE_AGE_MS = 15 * 60 * 1000; // 15 minutes past expiry
 const MAX_CACHE_SIZE = 500;
 
 export function oracleRouterRoutes(): Hono {
@@ -33,15 +37,19 @@ export function oracleRouterRoutes(): Hono {
       return c.json({ error: "Invalid mint address" }, 400);
     }
 
-    // Evict expired entries on every read
+    // Evict entries only once they are beyond the stale-fallback window so
+    // expired-but-still-usable entries survive long enough to back up the
+    // catch path below if the upstream oracle is down.
     const now = Date.now();
     for (const [key, entry] of cache) {
-      if (now >= entry.expiresAt) cache.delete(key);
+      if (now >= entry.expiresAt + MAX_STALE_AGE_MS) cache.delete(key);
     }
 
-    // Check cache — promote to most-recently-used on hit
+    // Capture once: used both for the fresh-cache fast path and as a
+    // potential stale fallback in the catch block.
     const cached = cache.get(mint);
     if (cached && now < cached.expiresAt) {
+      // Fresh hit — promote to most-recently-used and return.
       cache.delete(mint);
       cache.set(mint, cached);
       return c.json({ ...cached.result, cached: true });
@@ -77,6 +85,18 @@ export function oracleRouterRoutes(): Hono {
     } catch (err: any) {
       const detail = err instanceof Error ? err.message : String(err);
       logger.error("Oracle resolve error", { detail, path: c.req.path });
+
+      // Stale-while-error fallback: if we have an expired entry that is still
+      // within MAX_STALE_AGE_MS, serve it with stale: true so consumers know
+      // the data is degraded. Otherwise fall through to the original 500.
+      if (cached && Date.now() < cached.expiresAt + MAX_STALE_AGE_MS) {
+        logger.warn("Serving stale oracle cache after upstream error", {
+          mint,
+          stalenessMs: Date.now() - cached.expiresAt,
+        });
+        return c.json({ ...cached.result, cached: true, stale: true });
+      }
+
       return c.json({ error: "Failed to resolve oracle sources" }, 500);
     }
   });

--- a/tests/routes/oracle-router.test.ts
+++ b/tests/routes/oracle-router.test.ts
@@ -6,6 +6,7 @@ vi.mock("@percolatorct/sdk", () => ({
   resolvePrice: vi.fn(),
 }));
 
+// Mock @percolator/shared (only createLogger is used by oracle-router)
 vi.mock("@percolator/shared", () => ({
   createLogger: vi.fn(() => ({
     info: vi.fn(),
@@ -149,5 +150,90 @@ describe("oracle-router in-flight request dedup", () => {
       expect(res.status).toBe(500);
     }
     expect(resolvePrice).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("oracle-router stale-while-error fallback", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns fresh data on a successful resolve", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ...FRESH_RESULT, cached: false });
+    expect(body.stale).toBeUndefined();
+  });
+
+  it("returns 500 when resolvePrice fails and the cache is empty", async () => {
+    const { app, resolvePrice } = await loadApp();
+    resolvePrice.mockRejectedValueOnce(new Error("oracle down"));
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to resolve oracle sources");
+  });
+
+  it("falls back to stale cached data when resolvePrice fails within the stale window", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    // First call: success — populates the cache.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+    const ok = await app.request(makeRequest("TEST_MINT"));
+    expect(ok.status).toBe(200);
+
+    // Advance past the 5min TTL but stay within the 15min stale window.
+    vi.setSystemTime(new Date("2025-01-01T00:10:00Z"));
+    resolvePrice.mockRejectedValueOnce(new Error("oracle down"));
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ...FRESH_RESULT, cached: true, stale: true });
+  });
+
+  it("returns 500 when the stale entry is older than MAX_STALE_AGE_MS", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+    const ok = await app.request(makeRequest("TEST_MINT"));
+    expect(ok.status).toBe(200);
+
+    // Advance well past TTL + MAX_STALE_AGE (5 + 15 = 20 minutes).
+    vi.setSystemTime(new Date("2025-01-01T00:30:00Z"));
+    resolvePrice.mockRejectedValueOnce(new Error("oracle down"));
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(500);
+  });
+
+  it("prefers a fresh resolve over a stale cache entry", async () => {
+    const { app, resolvePrice } = await loadApp();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    resolvePrice.mockResolvedValueOnce(FRESH_RESULT);
+    await app.request(makeRequest("TEST_MINT"));
+
+    // Advance past TTL but the next resolve succeeds — should NOT mark stale.
+    vi.setSystemTime(new Date("2025-01-01T00:10:00Z"));
+    const NEW_RESULT = { ...FRESH_RESULT, sources: [{ name: "pyth", price: 200 }] };
+    resolvePrice.mockResolvedValueOnce(NEW_RESULT);
+
+    const res = await app.request(makeRequest("TEST_MINT"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ...NEW_RESULT, cached: false });
+    expect(body.stale).toBeUndefined();
   });
 });


### PR DESCRIPTION
Rebased from fork PR #143. Resolves conflict with #144 (in-flight dedup) by combining both: lazy eviction (entries survive past TTL within MAX_STALE_AGE_MS window), stale-while-error fallback on upstream failure, AND in-flight request coalescing.

Both test suites (stale-fallback + dedup) included.

Build: `pnpm build` clean.