### PR TITLE
fix(ws): clean up eventBus listeners on shutdown and re-entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { chartRoutes } from "./routes/chart.js";
 import { candleRoutes } from "./routes/candles.js";
 import { docsRoutes } from "./routes/docs.js";
 import { adlRoutes } from "./routes/adl.js";
-import { setupWebSocket, cleanupPriceUpdateTimers } from "./routes/ws.js";
+import { setupWebSocket, cleanupPriceUpdateTimers, cleanupEventBusListeners } from "./routes/ws.js";
 import { OraclePriceBroadcaster } from "./services/OraclePriceBroadcaster.js";
 import { readRateLimit, writeRateLimit } from "./middleware/rate-limit.js";
 import { ipBlocklist } from "./middleware/ip-blocklist.js";
@@ -387,8 +387,11 @@ async function shutdown(signal: string): Promise<void> {
       { name: "Signal", value: signal, inline: true },
     ]);
 
-    // Clean up pending price update timers before closing connections
+    // Clean up pending price update timers and unsubscribe shared eventBus
+    // listeners before closing connections, so they don't keep stale state
+    // alive past the process lifetime.
     cleanupPriceUpdateTimers();
+    cleanupEventBusListeners();
 
     // Terminate all active WebSocket connections so they don't hold the server open
     for (const client of wss.clients) {

--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -198,6 +198,15 @@ interface PendingPriceUpdate {
 const pendingPriceUpdates = new Map<string, PendingPriceUpdate>();
 const priceUpdateTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+// References to the eventBus listeners registered inside setupWebSocket().
+// We hold them at module scope so they can be removed via cleanupEventBus
+// Listeners() — both at the start of setupWebSocket() (idempotent re-entry,
+// important for tests that re-import this module) and on graceful shutdown.
+// Without this, repeated calls leak listeners on the shared eventBus singleton.
+let priceUpdatedListener: ((payload: any) => void) | null = null;
+let tradeExecutedListener: ((payload: any) => void) | null = null;
+let fundingUpdatedListener: ((payload: any) => void) | null = null;
+
 // Metrics tracking
 interface Metrics {
   totalConnections: number;
@@ -457,6 +466,11 @@ export function getWebSocketMetrics(): any {
 export function setupWebSocket(server: Server): WebSocketServer {
   const wss = new WebSocketServer({ server, maxPayload: 1024 });
 
+  // Idempotent re-entry: drop any listeners left over from a previous call
+  // (tests, hot reload, restart) before re-registering. The eventBus is a
+  // shared singleton, so without this listeners would accumulate.
+  cleanupEventBusListeners();
+
   wss.on("error", (err) => {
     logger.error("WebSocketServer error", {
       error: err instanceof Error ? err.message : String(err),
@@ -466,7 +480,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
   const clients = new Set<WsClient>();
 
   // Broadcast price updates to subscribed clients (with batching)
-  eventBus.on("price.updated", (payload: any) => {
+  priceUpdatedListener = (payload: any) => {
     try {
       const slabAddress = payload.slabAddress;
 
@@ -494,10 +508,11 @@ export function setupWebSocket(server: Server): WebSocketServer {
     } catch (err) {
       logger.error("Error in price.updated handler", { error: err instanceof Error ? err.message : String(err) });
     }
-  });
+  };
+  eventBus.on("price.updated", priceUpdatedListener);
 
   // Broadcast trade events to subscribed clients
-  eventBus.on("trade.executed", (payload: any) => {
+  tradeExecutedListener = (payload: any) => {
     try {
       const slabAddress = payload.slabAddress;
       const channel = `trades:${slabAddress}`;
@@ -528,10 +543,11 @@ export function setupWebSocket(server: Server): WebSocketServer {
     } catch (err) {
       logger.error("Error in trade.executed handler", { error: err instanceof Error ? err.message : String(err) });
     }
-  });
+  };
+  eventBus.on("trade.executed", tradeExecutedListener);
 
   // Broadcast funding rate updates to subscribed clients
-  eventBus.on("funding.updated", (payload: any) => {
+  fundingUpdatedListener = (payload: any) => {
     try {
       const slabAddress = payload.slabAddress;
       const channel = `funding:${slabAddress}`;
@@ -560,7 +576,8 @@ export function setupWebSocket(server: Server): WebSocketServer {
     } catch (err) {
       logger.error("Error in funding.updated handler", { error: err instanceof Error ? err.message : String(err) });
     }
-  });
+  };
+  eventBus.on("funding.updated", fundingUpdatedListener);
 
   wss.on("connection", (ws, req: IncomingMessage) => {
     const clientIp = getClientIp(req);
@@ -1157,4 +1174,28 @@ export function cleanupPriceUpdateTimers(): void {
   }
   priceUpdateTimers.clear();
   pendingPriceUpdates.clear();
+}
+
+/**
+ * Remove the eventBus listeners registered by setupWebSocket().
+ *
+ * The eventBus is a shared singleton (re-imported from @percolator/shared),
+ * so listeners registered inside setupWebSocket() persist across module
+ * reloads. Without this helper they would accumulate on every test that
+ * resets modules and on every graceful shutdown / restart cycle, causing
+ * duplicate broadcasts and a slow memory leak. Safe to call multiple times.
+ */
+export function cleanupEventBusListeners(): void {
+  if (priceUpdatedListener) {
+    eventBus.off("price.updated", priceUpdatedListener);
+    priceUpdatedListener = null;
+  }
+  if (tradeExecutedListener) {
+    eventBus.off("trade.executed", tradeExecutedListener);
+    tradeExecutedListener = null;
+  }
+  if (fundingUpdatedListener) {
+    eventBus.off("funding.updated", fundingUpdatedListener);
+    fundingUpdatedListener = null;
+  }
 }

--- a/tests/routes/ws-eventbus-cleanup.test.ts
+++ b/tests/routes/ws-eventbus-cleanup.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { eventBus } from "@percolator/shared";
+import { setupWebSocket, cleanupEventBusListeners } from "../../src/routes/ws.js";
+
+// Track baseline listener counts so the assertions are independent of any
+// listeners that might be registered by other parts of the system.
+let baseline: Record<string, number>;
+
+const TRACKED_EVENTS = ["price.updated", "trade.executed", "funding.updated"] as const;
+
+function snapshot(): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const e of TRACKED_EVENTS) {
+    out[e] = eventBus.listenerCount(e);
+  }
+  return out;
+}
+
+describe("ws.ts eventBus listener lifecycle", () => {
+  let server: Server;
+
+  beforeEach(() => {
+    cleanupEventBusListeners();
+    baseline = snapshot();
+    server = createServer();
+  });
+
+  afterEach(() => {
+    cleanupEventBusListeners();
+    server.close();
+  });
+
+  it("registers exactly one listener per tracked event after setupWebSocket", () => {
+    setupWebSocket(server);
+    const after = snapshot();
+    for (const e of TRACKED_EVENTS) {
+      expect(after[e]).toBe(baseline[e] + 1);
+    }
+  });
+
+  it("does not accumulate listeners across repeated setupWebSocket calls", () => {
+    setupWebSocket(server);
+    setupWebSocket(server);
+    setupWebSocket(server);
+    const after = snapshot();
+    for (const e of TRACKED_EVENTS) {
+      // Still only one listener per event regardless of how many times setup ran.
+      expect(after[e]).toBe(baseline[e] + 1);
+    }
+  });
+
+  it("cleanupEventBusListeners removes all registered listeners", () => {
+    setupWebSocket(server);
+    cleanupEventBusListeners();
+    const after = snapshot();
+    for (const e of TRACKED_EVENTS) {
+      expect(after[e]).toBe(baseline[e]);
+    }
+  });
+
+  it("cleanupEventBusListeners is safe to call when no listeners are registered", () => {
+    cleanupEventBusListeners();
+    cleanupEventBusListeners();
+    const after = snapshot();
+    for (const e of TRACKED_EVENTS) {
+      expect(after[e]).toBe(baseline[e]);
+    }
+  });
+});


### PR DESCRIPTION
Rebased from fork PR #146. Resolves conflict with OraclePriceBroadcaster import added by main after branch point. Exports cleanupEventBusListeners() and wires it into shutdown() alongside cleanupPriceUpdateTimers().