### PR TITLE
fix(ws): wrap every message-handler send in safeSend()

### DIFF
--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -228,6 +228,40 @@ const metrics: Metrics = {
   lastResetTime: Date.now(),
 };
 
+/**
+ * Safely send a JSON-serializable payload to a WebSocket client.
+ *
+ * The async message handler runs concurrently per message and contains
+ * `await`s, so the underlying socket can transition out of OPEN between
+ * any two statements. The `ws` library throws synchronously if `send()`
+ * is called when `readyState !== OPEN`, which would otherwise crash the
+ * handler closure halfway through processing a message. This helper
+ * centralises three things every send must do:
+ *
+ *   1. Check `readyState === OPEN` to avoid the throw on a closed socket.
+ *   2. Honour `bufferedAmount <= MAX_BUFFER_BYTES` for backpressure.
+ *   3. Catch any residual TOCTOU race where the socket closes between
+ *      the check and the send call itself, logging it as debug rather
+ *      than letting the error escape the handler.
+ *
+ * On a successful send, metrics are bumped so observability stays
+ * accurate without callers having to remember to do it themselves.
+ */
+function safeSend(ws: WebSocket, payload: unknown): void {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  if (ws.bufferedAmount > MAX_BUFFER_BYTES) return;
+  const serialized = JSON.stringify(payload);
+  try {
+    ws.send(serialized);
+    metrics.messagesSent++;
+    metrics.bytesSent += serialized.length;
+  } catch (err) {
+    logger.debug("safeSend dropped after socket transitioned out of OPEN", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 // Reset rate metrics every minute for messages/sec and bytes/sec
 setInterval(() => {
   const now = Date.now();
@@ -728,7 +762,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
       }, PONG_TIMEOUT_MS);
     }, HEARTBEAT_INTERVAL_MS);
 
-    ws.send(JSON.stringify({ type: "connected", message: "Percolator WebSocket connected" }));
+    safeSend(ws, { type: "connected", message: "Percolator WebSocket connected" });
 
     ws.on("error", (err) => {
       logger.warn("WebSocket connection error", {
@@ -747,7 +781,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
         
         // Limit message size
         if (rawStr.length > 1024) {
-          ws.send(JSON.stringify({ type: "error", message: "Message too large" }));
+          safeSend(ws, { type: "error", message: "Message too large" });
           return;
         }
 
@@ -759,7 +793,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
         }
         client.msgCount++;
         if (client.msgCount > CLIENT_MSG_LIMIT) {
-          ws.send(JSON.stringify({ type: "error", message: "Message rate limit exceeded" }));
+          safeSend(ws, { type: "error", message: "Message rate limit exceeded" });
           if (client.msgCount === CLIENT_MSG_LIMIT + 1) {
             logger.warn("Client message rate limit exceeded", { ip: client.ip });
           }
@@ -786,7 +820,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
                 currentSlab: client.authenticatedSlab,
                 requestedSlab: newSlab,
               });
-              ws.send(JSON.stringify({ type: "error", message: "Already authenticated — disconnect to change slab binding" }));
+              safeSend(ws, { type: "error", message: "Already authenticated — disconnect to change slab binding" });
               return;
             }
           }
@@ -809,7 +843,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
                   ip: client.ip,
                   count: ipCount,
                 });
-                ws.send(JSON.stringify({ type: "error", message: "Authenticated connection limit reached" }));
+                safeSend(ws, { type: "error", message: "Authenticated connection limit reached" });
                 ws.close(1008, "Connection limit reached");
                 return;
               }
@@ -827,22 +861,22 @@ export function setupWebSocket(server: Server): WebSocketServer {
               ip: client.ip, 
               slab: client.authenticatedSlab 
             });
-            ws.send(JSON.stringify({ 
-              type: "authenticated", 
-              slabBinding: client.authenticatedSlab 
-            }));
+            safeSend(ws, {
+              type: "authenticated",
+              slabBinding: client.authenticatedSlab,
+            });
           } else {
             logger.warn("Invalid auth token in message", { ip: client.ip });
             // Record auth failure for rate limiting (issue #839)
             recordAuthFailure(client.ip);
-            ws.send(JSON.stringify({ type: "error", message: "Invalid authentication token" }));
+            safeSend(ws, { type: "error", message: "Invalid authentication token" });
           }
           return;
         }
         
         // If auth required and not authenticated, reject all other messages
         if (WS_AUTH_REQUIRED && !client.authenticated) {
-          ws.send(JSON.stringify({ type: "error", message: "Authentication required" }));
+          safeSend(ws, { type: "error", message: "Authentication required" });
           return;
         }
         
@@ -850,7 +884,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
         if (msg.type === "subscribe" && msg.channels && Array.isArray(msg.channels)) {
           const MAX_CHANNELS_PER_MESSAGE = 50;
           if (msg.channels.length > MAX_CHANNELS_PER_MESSAGE) {
-            ws.send(JSON.stringify({ type: "error", message: `Max ${MAX_CHANNELS_PER_MESSAGE} channels per subscribe message` }));
+            safeSend(ws, { type: "error", message: `Max ${MAX_CHANNELS_PER_MESSAGE} channels per subscribe message` });
             return;
           }
 
@@ -929,7 +963,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
           }
           
           if (subscribed.length > 0) {
-            ws.send(JSON.stringify({ type: "subscribed", channels: subscribed }));
+            safeSend(ws, { type: "subscribed", channels: subscribed });
             
             // Send initial data for price channels
             for (const channel of subscribed) {
@@ -960,22 +994,18 @@ export function setupWebSocket(server: Server): WebSocketServer {
                   }
 
                   if (stats && stats.last_price) {
-                    if (ws.readyState === WebSocket.OPEN && ws.bufferedAmount <= MAX_BUFFER_BYTES) {
-                      // market_stats.last_price / mark_price / index_price are
-                      // stored as DOLLAR values (not e6-scaled), unlike
-                      // oracle_prices.price_e6. Previously we divided again by
-                      // 1e6 and sent \$0.00008555 on subscribe.
-                      ws.send(
-                        JSON.stringify({
-                          type: "price",
-                          slab,
-                          price: stats.last_price,
-                          markPrice: stats.mark_price ?? undefined,
-                          indexPrice: stats.index_price ?? undefined,
-                          timestamp: stats.updated_at,
-                        }),
-                      );
-                    }
+                    // market_stats.last_price / mark_price / index_price are
+                    // stored as DOLLAR values (not e6-scaled), unlike
+                    // oracle_prices.price_e6. Previously we divided again by
+                    // 1e6 and sent $0.00008555 on subscribe.
+                    safeSend(ws, {
+                      type: "price",
+                      slab,
+                      price: stats.last_price,
+                      markPrice: stats.mark_price ?? undefined,
+                      indexPrice: stats.index_price ?? undefined,
+                      timestamp: stats.updated_at,
+                    });
                   }
                 } catch (err) {
                   logger.warn("Failed to fetch initial price for subscription", {
@@ -988,20 +1018,20 @@ export function setupWebSocket(server: Server): WebSocketServer {
           }
           
           if (errors.length > 0) {
-            ws.send(JSON.stringify({ type: "error", message: errors.join("; ") }));
+            safeSend(ws, { type: "error", message: errors.join("; ") });
           }
         }
         // Legacy: single slab subscription (backward compatibility)
         else if (msg.type === "subscribe" && msg.slabAddress) {
           const sanitized = sanitizeSlabAddress(msg.slabAddress);
           if (!sanitized) {
-            ws.send(JSON.stringify({ type: "error", message: "Invalid slab address" }));
+            safeSend(ws, { type: "error", message: "Invalid slab address" });
             return;
           }
 
           // Reject blocked/phantom slabs
           if (isBlockedSlab(sanitized)) {
-            ws.send(JSON.stringify({ type: "error", message: "Market not found" }));
+            safeSend(ws, { type: "error", message: "Market not found" });
             return;
           }
           
@@ -1012,26 +1042,26 @@ export function setupWebSocket(server: Server): WebSocketServer {
               authenticatedSlab: client.authenticatedSlab, 
               requestedSlab: sanitized 
             });
-            ws.send(JSON.stringify({
+            safeSend(ws, {
               type: "error",
-              message: "Cannot subscribe — token is bound to a different market"
-            }));
+              message: "Cannot subscribe — token is bound to a different market",
+            });
             return;
           }
           
           // Check per-slab connection limit before subscribing
           const slabClients = connectionsPerSlab.get(sanitized);
           if (slabClients && slabClients.size >= MAX_CONNECTIONS_PER_SLAB) {
-            ws.send(JSON.stringify({ type: "error", message: "Connection limit for this market reached" }));
+            safeSend(ws, { type: "error", message: "Connection limit for this market reached" });
             return;
           }
 
           // Subscribe to all channels for this slab (backward compatibility)
           const channels = [`price:${sanitized}`, `trades:${sanitized}`, `funding:${sanitized}`];
-          ws.send(JSON.stringify({ 
-            type: "info", 
-            message: "Please use channels array. Subscribing to all channels for this slab." 
-          }));
+          safeSend(ws, {
+            type: "info",
+            message: "Please use channels array. Subscribing to all channels for this slab.",
+          });
           
           const subscribed: string[] = [];
           for (const channel of channels) {
@@ -1047,15 +1077,15 @@ export function setupWebSocket(server: Server): WebSocketServer {
           if (subscribed.length > 0) {
             addClientToSlab(client, sanitized);
           }
-          ws.send(JSON.stringify({ type: "subscribed", slabAddress: sanitized, channels: subscribed }));
+          safeSend(ws, { type: "subscribed", slabAddress: sanitized, channels: subscribed });
           if (subscribed.length < channels.length) {
-            ws.send(JSON.stringify({ type: "error", message: "Subscription limit reached — some channels were not subscribed" }));
+            safeSend(ws, { type: "error", message: "Subscription limit reached — some channels were not subscribed" });
           }
         }
         // Handle unsubscribe with channels array
         else if (msg.type === "unsubscribe" && msg.channels && Array.isArray(msg.channels)) {
           if (msg.channels.length > MAX_SUBSCRIPTIONS_PER_CLIENT) {
-            ws.send(JSON.stringify({ type: "error", message: "Too many channels in unsubscribe message" }));
+            safeSend(ws, { type: "error", message: "Too many channels in unsubscribe message" });
             return;
           }
 
@@ -1080,7 +1110,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
           }
           
           if (unsubscribed.length > 0) {
-            ws.send(JSON.stringify({ type: "unsubscribed", channels: unsubscribed }));
+            safeSend(ws, { type: "unsubscribed", channels: unsubscribed });
           }
         }
         // Legacy: single slab unsubscribe
@@ -1098,14 +1128,12 @@ export function setupWebSocket(server: Server): WebSocketServer {
             }
             
             removeClientFromSlab(client, sanitized);
-            ws.send(JSON.stringify({ type: "unsubscribed", slabAddress: sanitized, channels: unsubscribed }));
+            safeSend(ws, { type: "unsubscribed", slabAddress: sanitized, channels: unsubscribed });
           }
         }
       } catch (err) {
         logger.warn("Error processing WS message", { ip: client.ip, error: err });
-        if (ws.readyState === WebSocket.OPEN && ws.bufferedAmount <= MAX_BUFFER_BYTES) {
-          ws.send(JSON.stringify({ type: "error", message: "Invalid message" }));
-        }
+        safeSend(ws, { type: "error", message: "Invalid message" });
       }
     });
 

--- a/tests/routes/ws-safe-send.test.ts
+++ b/tests/routes/ws-safe-send.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression: every ws.send() inside the WS message handler must be wrapped
+ * by safeSend(), so a synchronous "WebSocket is not open" throw cannot escape
+ * the async handler when the client disconnects mid-iteration.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import WebSocket from "ws";
+
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  eventBus: { on: vi.fn() },
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          abortSignal: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+          })),
+          single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+        })),
+      })),
+    })),
+  })),
+  sanitizeSlabAddress: vi.fn((s: string) => s),
+  sendInfoAlert: vi.fn(),
+}));
+
+interface TestServer {
+  server: http.Server;
+  port: number;
+}
+
+async function startServer(): Promise<TestServer> {
+  Object.assign(process.env, { NODE_ENV: "test", WS_AUTH_REQUIRED: "false" });
+  vi.resetModules();
+  const { setupWebSocket } = await import("../../src/routes/ws.js");
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+  setupWebSocket(server as unknown as import("node:http").Server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as { port: number };
+  return { server, port };
+}
+
+function stopServer(ts: TestServer): Promise<void> {
+  return new Promise((resolve, reject) =>
+    ts.server.close((err) => (err ? reject(err) : resolve())),
+  );
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) return resolve();
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+}
+
+function waitForClose(ws: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) return resolve();
+    ws.once("close", () => resolve());
+  });
+}
+
+describe("WS message handler — safeSend hardening", () => {
+  let ts: TestServer;
+  // Capture any uncaught exceptions during the test so we can fail loudly if
+  // an unguarded ws.send() throw escapes the handler.
+  let uncaughtErrors: unknown[] = [];
+  const onUncaught = (err: unknown) => uncaughtErrors.push(err);
+
+  beforeEach(() => {
+    uncaughtErrors = [];
+    process.on("uncaughtException", onUncaught);
+    process.on("unhandledRejection", onUncaught);
+  });
+
+  afterEach(async () => {
+    process.off("uncaughtException", onUncaught);
+    process.off("unhandledRejection", onUncaught);
+    if (ts) await stopServer(ts);
+    delete process.env.WS_AUTH_REQUIRED;
+  });
+
+  it("does not crash the handler when the client closes immediately after sending an oversized message", async () => {
+    ts = await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${ts.port}/`);
+    await waitForOpen(ws);
+
+    // Build a payload larger than MAX_PAYLOAD (currently 1024) to trip the
+    // "Message too large" path that previously did an unguarded ws.send().
+    // Use the raw WS frame so the send isn't pre-validated by ws library.
+    const huge = "x".repeat(2048);
+    ws.send(huge);
+    // Close the socket immediately so by the time the server's "Message too
+    // large" send fires, the readyState may not be OPEN any more.
+    ws.terminate();
+    await waitForClose(ws);
+
+    // Give the handler a moment to settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(uncaughtErrors).toEqual([]);
+  });
+
+  it("does not crash the handler when the client disconnects immediately after subscribe", async () => {
+    ts = await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${ts.port}/`);
+    await waitForOpen(ws);
+
+    ws.send(JSON.stringify({ type: "subscribe", channels: ["price:SLAB1"] }));
+    // Don't wait for the "subscribed" reply — terminate so by the time the
+    // server tries to write to us we are closed.
+    ws.terminate();
+    await waitForClose(ws);
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(uncaughtErrors).toEqual([]);
+  });
+
+  it("delivers normal subscribe responses to a connected client", async () => {
+    ts = await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${ts.port}/`);
+    await waitForOpen(ws);
+
+    const msgPromise = new Promise<any>((resolve, reject) => {
+      ws.on("message", (raw) => {
+        try {
+          const parsed = JSON.parse(String(raw));
+          if (parsed.type === "subscribed") resolve(parsed);
+        } catch (err) {
+          reject(err);
+        }
+      });
+      setTimeout(() => reject(new Error("timeout")), 1500);
+    });
+
+    ws.send(JSON.stringify({ type: "subscribe", channels: ["price:SLAB1"] }));
+    const msg = await msgPromise;
+    expect(msg.type).toBe("subscribed");
+    expect(msg.channels).toContain("price:SLAB1");
+
+    ws.close();
+    await waitForClose(ws);
+    expect(uncaughtErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Rebased from fork PR #149. Conflict in ws.ts resolved: used safeSend() for message handler sends while keeping main's correct un-divided price values (the division bug was fixed in main before this PR was rebased).