### PR TITLE
fix: add RPC fallback with timeout for on-chain reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ WS_AUTH_SECRET=
 # For mainnet: use a paid RPC provider (Helius, Alchemy, etc.) — the public
 # endpoint rate-limits aggressively and is unsuitable for production.
 RPC_URL=https://api.mainnet-beta.solana.com
+# Fallback RPC — used automatically when primary is down or rate-limited.
+# IMPORTANT: defaults to devnet if unset — must be set for mainnet deployments.
+FALLBACK_RPC_URL=
 
 # Supabase
 SUPABASE_URL=

--- a/src/routes/adl.ts
+++ b/src/routes/adl.ts
@@ -50,7 +50,8 @@ import {
   createLogger,
   sanitizeSlabAddress,
 } from "@percolator/shared";
-import { withRpcTimeout, RpcTimeoutError } from "../utils/rpc-timeout.js";
+import { withRpcFallback } from "../utils/rpc-fallback.js";
+import { RpcTimeoutError } from "../utils/rpc-timeout.js";
 import { isBlockedSlab } from "../middleware/validateSlab.js";
 
 const logger = createLogger("api:adl");
@@ -184,11 +185,11 @@ export function adlRoutes(): Hono {
       return c.json({ error: "Market not found" }, 404);
     }
 
-    const connection = getConnection();
     let data: Uint8Array;
     try {
-      data = await withRpcTimeout(
-        fetchSlab(connection, new PublicKey(slab)),
+      data = await withRpcFallback(
+        (conn) => fetchSlab(conn, new PublicKey(slab)),
+        getConnection(),
         `fetchSlab(${slab})`,
       );
     } catch (err) {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { getConnection, getSupabase, createLogger, truncateErrorMessage } from "@percolator/shared";
-import { withRpcTimeout, HEALTH_RPC_TIMEOUT_MS } from "../utils/rpc-timeout.js";
+
+import { withRpcFallback } from "../utils/rpc-fallback.js";
+import { HEALTH_RPC_TIMEOUT_MS } from "../utils/rpc-timeout.js";
 import { getWebSocketMetrics } from "./ws.js";
 import { requireApiKey } from "../middleware/auth.js";
 
@@ -27,7 +29,12 @@ export function healthRoutes(): Hono {
     
     // Check RPC connectivity
     try {
-      await withRpcTimeout(getConnection().getSlot(), "healthcheck:getSlot", HEALTH_RPC_TIMEOUT_MS);
+      await withRpcFallback(
+        (conn) => conn.getSlot(),
+        getConnection(),
+        "healthcheck:getSlot",
+        HEALTH_RPC_TIMEOUT_MS,
+      );
       checks.rpc = true;
     } catch (err) {
       logger.error("RPC check failed", { error: truncateErrorMessage(err instanceof Error ? err.message : err, 120) });

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -5,7 +5,8 @@ import { cacheMiddleware } from "../middleware/cache.js";
 import { withDbCacheFallback } from "../middleware/db-cache-fallback.js";
 import { fetchSlab, parseHeader, parseConfig, parseEngine } from "@percolatorct/sdk";
 import { getConnection, getSupabase, getNetwork, createLogger, sanitizeSlabAddress, truncateErrorMessage } from "@percolator/shared";
-import { withRpcTimeout, RpcTimeoutError } from "../utils/rpc-timeout.js";
+import { withRpcFallback } from "../utils/rpc-fallback.js";
+import { RpcTimeoutError } from "../utils/rpc-timeout.js";
 
 const logger = createLogger("api:markets");
 
@@ -124,10 +125,10 @@ export function marketRoutes(): Hono {
     const slab = c.req.param("slab");
     if (!slab) return c.json({ error: "slab required" }, 400);
     try {
-      const connection = getConnection();
       const slabPubkey = new PublicKey(slab);
-      const data = await withRpcTimeout(
-        fetchSlab(connection, slabPubkey),
+      const data = await withRpcFallback(
+        (conn) => fetchSlab(conn, slabPubkey),
+        getConnection(),
         `fetchSlab(${slab})`,
       );
       const header = parseHeader(data);

--- a/src/utils/rpc-fallback.ts
+++ b/src/utils/rpc-fallback.ts
@@ -1,0 +1,47 @@
+/**
+ * RPC failover for read-only on-chain calls.
+ *
+ * Tries the primary connection first; on ANY error, retries once against
+ * the fallback connection (FALLBACK_RPC_URL).  Each attempt is independently
+ * wrapped in withRpcTimeout so a hung primary doesn't consume the fallback's
+ * timeout budget.
+ *
+ * If FALLBACK_RPC_URL is not explicitly set, the original primary error is
+ * re-thrown unchanged.  This prevents silent failover to the devnet default
+ * that @percolator/shared uses when the env var is missing.
+ */
+
+import type { Connection } from "@solana/web3.js";
+import { getFallbackConnection, createLogger } from "@percolator/shared";
+import { withRpcTimeout } from "./rpc-timeout.js";
+
+const logger = createLogger("api:rpc-fallback");
+
+/** True only when the operator has explicitly configured a fallback RPC. */
+const hasFallbackRpc = Boolean(process.env.FALLBACK_RPC_URL);
+
+export async function withRpcFallback<T>(
+  fn: (conn: Connection) => Promise<T>,
+  primary: Connection,
+  operation: string,
+  timeoutMs?: number,
+): Promise<T> {
+  try {
+    return await withRpcTimeout(fn(primary), operation, timeoutMs);
+  } catch (primaryErr) {
+    if (!hasFallbackRpc) {
+      throw primaryErr; // no explicit fallback configured — re-throw original
+    }
+
+    logger.warn("Primary RPC failed, trying fallback", {
+      operation,
+      error: primaryErr instanceof Error ? primaryErr.message : String(primaryErr),
+    });
+
+    return await withRpcTimeout(
+      fn(getFallbackConnection()),
+      `${operation}[fallback]`,
+      timeoutMs,
+    );
+  }
+}


### PR DESCRIPTION
Rebased from fork PR #154. Adds rpc-fallback.ts (withRpcFallback) and upgrades health, markets, and adl routes to use it for primary+fallback RPC resilience. Conflict with main's rpc-timeout.ts (#153) resolved by keeping both utilities.