### PR TITLE
fix: add DB stale-cache fallback to stats, prices, markets/stats, and crank

### DIFF
--- a/src/routes/crank.ts
+++ b/src/routes/crank.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getSupabase, getNetwork, createLogger, truncateErrorMessage } from "@percolator/shared";
+import { withDbCacheFallback } from "../middleware/db-cache-fallback.js";
 
 const logger = createLogger("api:crank");
 
@@ -7,20 +8,25 @@ export function crankStatusRoutes(): Hono {
   const app = new Hono();
 
   app.get("/crank/status", async (c) => {
-    try {
-      const { data, error } = await getSupabase()
-        .from("markets_with_stats")
-        .select("slab_address, last_crank_slot, updated_at")
-        .eq("network", getNetwork())
-        .not("slab_address", "is", null);
-      if (error) throw error;
-      return c.json({ markets: data ?? [] });
-    } catch (err) {
-      logger.error("Error fetching crank status", {
-        error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120),
-      });
-      return c.json({ error: "Failed to fetch crank status" }, 500);
+    const result = await withDbCacheFallback(
+      "crank:status",
+      async () => {
+        const { data, error } = await getSupabase()
+          .from("markets_with_stats")
+          .select("slab_address, last_crank_slot, updated_at")
+          .eq("network", getNetwork())
+          .not("slab_address", "is", null);
+        if (error) throw error;
+        return data ?? [];
+      },
+      c
+    );
+
+    if (result instanceof Response) {
+      return result;
     }
+
+    return c.json({ markets: result });
   });
 
   return app;

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -84,20 +84,25 @@ export function marketRoutes(): Hono {
 
   // GET /markets/stats — all market stats from DB (filtered by network)
   app.get("/markets/stats", async (c) => {
-    try {
-      const { data, error } = await getSupabase()
-        .from("markets_with_stats")
-        .select("slab_address, total_open_interest, total_accounts, last_crank_slot, last_price, mark_price, index_price, funding_rate, net_lp_pos, lp_sum_abs, lp_max_abs, insurance_balance, insurance_fee_revenue, volume_24h, updated_at")
-        .eq("network", getNetwork())
-        .not("slab_address", "is", null);
-      if (error) throw error;
-      return c.json({ stats: data ?? [] });
-    } catch (err) {
-      logger.error("Error fetching all market stats", {
-        error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120),
-      });
-      return c.json({ error: "Failed to fetch market stats" }, 500);
+    const result = await withDbCacheFallback(
+      "markets:stats",
+      async () => {
+        const { data, error } = await getSupabase()
+          .from("markets_with_stats")
+          .select("slab_address, total_open_interest, total_accounts, last_crank_slot, last_price, mark_price, index_price, funding_rate, net_lp_pos, lp_sum_abs, lp_max_abs, insurance_balance, insurance_fee_revenue, volume_24h, updated_at")
+          .eq("network", getNetwork())
+          .not("slab_address", "is", null);
+        if (error) throw error;
+        return data ?? [];
+      },
+      c
+    );
+
+    if (result instanceof Response) {
+      return result;
     }
+
+    return c.json({ stats: result });
   });
 
   // GET /markets/:slab/stats — single market stats from DB

--- a/src/routes/prices.ts
+++ b/src/routes/prices.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { getSupabase, getNetwork, createLogger, truncateErrorMessage } from "@percolator/shared";
 import { validateSlab, isBlockedSlab } from "../middleware/validateSlab.js";
+import { withDbCacheFallback } from "../middleware/db-cache-fallback.js";
 
 const logger = createLogger("api:prices");
 
@@ -18,29 +19,33 @@ export function priceRoutes(): Hono {
     typeof v === "number" && Number.isFinite(v) && v > 0 && v <= MAX_SANE_PRICE_USD ? v : null;
 
   app.get("/prices/markets", async (c) => {
-    try {
-      const { data, error } = await getSupabase()
-        .from("markets_with_stats")
-        .select("slab_address, last_price, mark_price, index_price, updated_at")
-        .eq("network", getNetwork())
-        .not("slab_address", "is", null);
-      if (error) throw error;
-      const markets = (data ?? [])
-        .filter((m) => !isBlockedSlab(m.slab_address))
-        .map((m) => ({
-          slab_address: m.slab_address,
-          last_price: sanitizeUsdPrice(m.last_price),
-          mark_price: sanitizeUsdPrice(m.mark_price),
-          index_price: sanitizeUsdPrice(m.index_price),
-          updated_at: m.updated_at,
-        }));
-      return c.json({ markets });
-    } catch (err) {
-      logger.error("Error fetching market prices", {
-        error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120),
-      });
-      return c.json({ error: "Failed to fetch prices" }, 500);
+    const result = await withDbCacheFallback(
+      "prices:markets",
+      async () => {
+        const { data, error } = await getSupabase()
+          .from("markets_with_stats")
+          .select("slab_address, last_price, mark_price, index_price, updated_at")
+          .eq("network", getNetwork())
+          .not("slab_address", "is", null);
+        if (error) throw error;
+        return (data ?? [])
+          .filter((m) => !isBlockedSlab(m.slab_address))
+          .map((m) => ({
+            slab_address: m.slab_address,
+            last_price: sanitizeUsdPrice(m.last_price),
+            mark_price: sanitizeUsdPrice(m.mark_price),
+            index_price: sanitizeUsdPrice(m.index_price),
+            updated_at: m.updated_at,
+          }));
+      },
+      c
+    );
+
+    if (result instanceof Response) {
+      return result;
     }
+
+    return c.json({ markets: result });
   });
 
   app.get("/prices/:slab", validateSlab, async (c) => {

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -10,6 +10,7 @@
  */
 import { Hono } from "hono";
 import { getSupabase, getNetwork, createLogger, truncateErrorMessage } from "@percolator/shared";
+import { withDbCacheFallback } from "../middleware/db-cache-fallback.js";
 
 const logger = createLogger("api:stats");
 
@@ -31,69 +32,73 @@ export function statsRoutes(): Hono {
    * }
    */
   app.get("/stats", async (c) => {
-    try {
-      const network = getNetwork();
+    const result = await withDbCacheFallback(
+      "stats:platform",
+      async () => {
+        const network = getNetwork();
 
-      // Count total markets — filter by network to prevent devnet/mainnet mixing (PERC-8192)
-      const { count: marketsCount, error: marketsError } = await getSupabase()
-        .from("markets")
-        .select("*", { count: "exact", head: true })
-        .eq("network", network);
+        // Count total markets — filter by network to prevent devnet/mainnet mixing (PERC-8192)
+        const { count: marketsCount, error: marketsError } = await getSupabase()
+          .from("markets")
+          .select("*", { count: "exact", head: true })
+          .eq("network", network);
 
-      if (marketsError) throw marketsError;
+        if (marketsError) throw marketsError;
 
-      // Aggregate stats from markets_with_stats view — filter by network to
-      // prevent cross-network volume/OI inflation in shared DB deployments.
-      const { data: stats, error: statsError } = await getSupabase()
-        .from("markets_with_stats")
-        .select("volume_24h, total_open_interest")
-        .eq("network", network)
-        .not("slab_address", "is", null);
+        // Aggregate stats from markets_with_stats view — filter by network to
+        // prevent cross-network volume/OI inflation in shared DB deployments.
+        const { data: stats, error: statsError } = await getSupabase()
+          .from("markets_with_stats")
+          .select("volume_24h, total_open_interest")
+          .eq("network", network)
+          .not("slab_address", "is", null);
 
-      if (statsError) throw statsError;
+        if (statsError) throw statsError;
 
-      const safeBigInt = (val: unknown): bigint => {
-        try { return BigInt(val as string); } catch { return 0n; }
-      };
-      const volume24h = (stats ?? []).reduce((sum, s) => sum + safeBigInt(s.volume_24h ?? "0"), 0n);
-      const totalOI = (stats ?? []).reduce((sum, s) => sum + safeBigInt(s.total_open_interest ?? "0"), 0n);
+        const safeBigInt = (val: unknown): bigint => {
+          try { return BigInt(val as string); } catch { return 0n; }
+        };
+        const volume24h = (stats ?? []).reduce((sum, s) => sum + safeBigInt(s.volume_24h ?? "0"), 0n);
+        const totalOI = (stats ?? []).reduce((sum, s) => sum + safeBigInt(s.total_open_interest ?? "0"), 0n);
 
-      // Count unique deployers — filter by network
-      const { data: deployers, error: deployersError } = await getSupabase()
-        .from("markets")
-        .select("deployer")
-        .eq("network", network);
+        // Count unique deployers — filter by network
+        const { data: deployers, error: deployersError } = await getSupabase()
+          .from("markets")
+          .select("deployer")
+          .eq("network", network);
 
-      if (deployersError) throw deployersError;
+        if (deployersError) throw deployersError;
 
-      const uniqueDeployers = new Set((deployers ?? []).map((d) => d.deployer)).size;
+        const uniqueDeployers = new Set((deployers ?? []).map((d) => d.deployer)).size;
 
-      // Count 24h trades — filter by network
-      // NOTE: trades table uses `created_at` (TIMESTAMPTZ), not `timestamp`.
-      // The `timestamp` column exists only on oracle_prices/funding_history/oi_history.
-      const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-      const { count: trades24h, error: tradesError } = await getSupabase()
-        .from("trades")
-        .select("*", { count: "exact", head: true })
-        .eq("network", network)
-        .gte("created_at", since24h);
+        // Count 24h trades — filter by network
+        // NOTE: trades table uses `created_at` (TIMESTAMPTZ), not `timestamp`.
+        // The `timestamp` column exists only on oracle_prices/funding_history/oi_history.
+        const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        const { count: trades24h, error: tradesError } = await getSupabase()
+          .from("trades")
+          .select("*", { count: "exact", head: true })
+          .eq("network", network)
+          .gte("created_at", since24h);
 
-      if (tradesError) throw tradesError;
+        if (tradesError) throw tradesError;
 
-      return c.json({
-        totalMarkets: marketsCount ?? 0,
-        volume24h: volume24h.toString(),
-        totalOpenInterest: totalOI.toString(),
-        uniqueDeployers,
-        trades24h: trades24h ?? 0,
-      });
-    } catch (err) {
-      logger.error("Error fetching platform stats", { error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120) });
-      return c.json({ 
-        error: "Failed to fetch platform statistics",
-        ...(process.env.NODE_ENV !== "production" && { details: truncateErrorMessage(err instanceof Error ? err.message : String(err), 200) })
-      }, 500);
+        return {
+          totalMarkets: marketsCount ?? 0,
+          volume24h: volume24h.toString(),
+          totalOpenInterest: totalOI.toString(),
+          uniqueDeployers,
+          trades24h: trades24h ?? 0,
+        };
+      },
+      c
+    );
+
+    if (result instanceof Response) {
+      return result;
     }
+
+    return c.json(result);
   });
 
   return app;

--- a/tests/routes/crank.test.ts
+++ b/tests/routes/crank.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { crankStatusRoutes } from "../../src/routes/crank.js";
+import { clearDbCache } from "../../src/middleware/db-cache-fallback.js";
 
 // Mock @percolator/shared
 vi.mock("@percolator/shared", () => ({
@@ -45,6 +46,7 @@ describe("crank routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearDbCache();
 
     mockSupabase = {
       from: vi.fn(() => chainable({ data: [], error: null })),
@@ -112,7 +114,7 @@ describe("crank routes", () => {
       expect(data.markets[0].updated_at).toBeNull();
     });
 
-    it("should handle database errors", async () => {
+    it("should handle database errors with 503 (no stale cache)", async () => {
       mockSupabase.from.mockReturnValue(chainable({
         data: null,
         error: new Error("Database error"),
@@ -121,9 +123,10 @@ describe("crank routes", () => {
       const app = crankStatusRoutes();
       const res = await app.request("/crank/status");
 
-      expect(res.status).toBe(500);
+      // withDbCacheFallback returns 503 when DB fails and no stale cache is available
+      expect(res.status).toBe(503);
       const data = await res.json();
-      expect(data.error).toBe("Failed to fetch crank status");
+      expect(data.error).toBe("Database temporarily unavailable");
     });
 
     it("should return all market stats fields", async () => {

--- a/tests/routes/prices.test.ts
+++ b/tests/routes/prices.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { priceRoutes } from "../../src/routes/prices.js";
+import { clearDbCache } from "../../src/middleware/db-cache-fallback.js";
 
 // Mock @percolator/shared
 vi.mock("@percolator/shared", () => ({
@@ -30,6 +31,7 @@ describe("prices routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearDbCache();
 
     mockSupabase = {
       from: vi.fn(() => mockSupabase),
@@ -73,18 +75,19 @@ describe("prices routes", () => {
       expect(data.markets[0].slab_address).toBe("11111111111111111111111111111111");
     });
 
-    it("should handle database errors", async () => {
-      mockSupabase.not.mockResolvedValue({ 
-        data: null, 
-        error: new Error("Database error") 
+    it("should handle database errors with 503 (no stale cache)", async () => {
+      mockSupabase.not.mockResolvedValue({
+        data: null,
+        error: new Error("Database error")
       });
 
       const app = priceRoutes();
       const res = await app.request("/prices/markets");
 
-      expect(res.status).toBe(500);
+      // withDbCacheFallback returns 503 when DB fails and no stale cache is available
+      expect(res.status).toBe(503);
       const data = await res.json();
-      expect(data.error).toBe("Failed to fetch prices");
+      expect(data.error).toBe("Database temporarily unavailable");
     });
 
     it("should handle empty markets list", async () => {

--- a/tests/routes/stats.test.ts
+++ b/tests/routes/stats.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { statsRoutes } from "../../src/routes/stats.js";
+import { clearDbCache } from "../../src/middleware/db-cache-fallback.js";
 
 // Mock @percolator/shared
 vi.mock("@percolator/shared", () => ({
@@ -48,6 +49,7 @@ describe("stats routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearDbCache();
 
     // Create a chainable mock that supports the full Supabase query builder pattern.
     // All filter/modifier methods return `mockSupabase` to allow arbitrary chaining.
@@ -324,7 +326,7 @@ describe("stats routes", () => {
       expect(typeof data.trades24h).toBe("number");
     });
 
-    it("should handle database errors", async () => {
+    it("should handle database errors with 503 (no stale cache)", async () => {
       mockSupabase.from.mockImplementation((_table: string) => {
         return chainable({ count: null, data: null, error: new Error("Database error") });
       });
@@ -332,9 +334,10 @@ describe("stats routes", () => {
       const app = statsRoutes();
       const res = await app.request("/stats");
 
-      expect(res.status).toBe(500);
+      // withDbCacheFallback returns 503 when DB fails and no stale cache is available
+      expect(res.status).toBe(503);
       const data = await res.json();
-      expect(data.error).toBe("Failed to fetch platform statistics");
+      expect(data.error).toBe("Database temporarily unavailable");
     });
   });
 });


### PR DESCRIPTION
Rebased from fork PR #164. Adds withDbCacheFallback wrapping to GET /stats, GET /prices/markets, GET /markets/stats, and GET /crank/status — serving stale cached data on DB outage instead of 500. Conflicts with #182 (price sanitization) and main's extra columns resolved by keeping all improvements.