### PR TITLE
fix(api): preserve route-specific security headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { OraclePriceBroadcaster } from "./services/OraclePriceBroadcaster.js";
 import { readRateLimit, writeRateLimit } from "./middleware/rate-limit.js";
 import { ipBlocklist } from "./middleware/ip-blocklist.js";
 import { cacheMiddleware } from "./middleware/cache.js";
+import { securityHeaders } from "./middleware/security-headers.js";
 
 const logger = createLogger("api");
 
@@ -162,38 +163,7 @@ app.use("*", compress());
 app.use("*", sentryMiddleware());
 
 // Security Headers Middleware
-app.use("*", async (c, next) => {
-  await next();
-  
-  c.header("X-Content-Type-Options", "nosniff");
-  c.header("X-Frame-Options", "DENY");
-  c.header("X-XSS-Protection", "0");
-  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-  c.header("X-DNS-Prefetch-Control", "off");
-  c.header("X-Download-Options", "noopen");
-  c.header("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()");
-  
-  c.header("Content-Security-Policy", "default-src 'none'; script-src 'self' unpkg.com; style-src 'self' unpkg.com 'unsafe-inline'; connect-src 'self'; img-src 'self'; frame-ancestors 'none'");
-  
-  // Always send HSTS in production (proxy terminates TLS so x-forwarded-proto may be stripped by a MitM)
-  if (process.env.NODE_ENV === "production") {
-    c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
-  } else {
-    const proto = c.req.header("x-forwarded-proto") || "http";
-    if (proto === "https") {
-      c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
-    }
-  }
-
-  // Prevent CDNs/proxies from caching responses by default.
-  // Financial data endpoints (prices, funding, trades, stats) must not be
-  // served stale by intermediate proxies.  Endpoints that intentionally
-  // cache (e.g. /chart, cacheMiddleware routes) set their own
-  // Cache-Control header which will already be present on the response.
-  if (!c.res.headers.has("Cache-Control")) {
-    c.header("Cache-Control", "no-store");
-  }
-});
+app.use("*", securityHeaders());
 
 // Rate Limiting Middleware
 app.use("*", async (c, next) => {

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -1,0 +1,44 @@
+import { createMiddleware } from "hono/factory";
+
+const DEFAULT_CONTENT_SECURITY_POLICY =
+  "default-src 'none'; script-src 'self' unpkg.com; style-src 'self' unpkg.com 'unsafe-inline'; connect-src 'self'; img-src 'self'; frame-ancestors 'none'";
+
+const PERMISSIONS_POLICY =
+  "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()";
+
+/**
+ * Applies global security headers without overwriting route-specific headers.
+ *
+ * Some routes, such as /docs, need a more specific Content-Security-Policy
+ * to allow hashed inline initialization scripts without using unsafe-inline.
+ */
+export function securityHeaders() {
+  return createMiddleware(async (c, next) => {
+    await next();
+
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("X-XSS-Protection", "0");
+    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+    c.header("X-DNS-Prefetch-Control", "off");
+    c.header("X-Download-Options", "noopen");
+    c.header("Permissions-Policy", PERMISSIONS_POLICY);
+
+    if (!c.res.headers.has("Content-Security-Policy")) {
+      c.header("Content-Security-Policy", DEFAULT_CONTENT_SECURITY_POLICY);
+    }
+
+    if (process.env.NODE_ENV === "production") {
+      c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    } else {
+      const proto = c.req.header("x-forwarded-proto") || "http";
+      if (proto === "https") {
+        c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+      }
+    }
+
+    if (!c.res.headers.has("Cache-Control")) {
+      c.header("Cache-Control", "no-store");
+    }
+  });
+}

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { securityHeaders } from "../src/middleware/security-headers.js";
+
+describe("securityHeaders", () => {
+  it("preserves route-specific Content-Security-Policy headers", async () => {
+    const app = new Hono();
+
+    app.use("*", securityHeaders());
+    app.get("/docs", (c) => {
+      c.header(
+        "Content-Security-Policy",
+        "script-src 'self' unpkg.com 'sha256-test'; style-src 'self' unpkg.com 'unsafe-inline'",
+      );
+      return c.text("docs");
+    });
+
+    const res = await app.request("/docs");
+
+    expect(res.headers.get("Content-Security-Policy")).toBe(
+      "script-src 'self' unpkg.com 'sha256-test'; style-src 'self' unpkg.com 'unsafe-inline'",
+    );
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("sets the default Content-Security-Policy when a route does not define one", async () => {
+    const app = new Hono();
+
+    app.use("*", securityHeaders());
+    app.get("/markets", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/markets");
+    const csp = res.headers.get("Content-Security-Policy");
+
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("script-src 'self' unpkg.com");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("preserves route-specific Cache-Control headers", async () => {
+    const app = new Hono();
+
+    app.use("*", securityHeaders());
+    app.get("/cached", (c) => {
+      c.header("Cache-Control", "public, max-age=60");
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/cached");
+
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted the global security headers middleware into a dedicated helper
- Preserved route-specific `Content-Security-Policy` headers instead of overwriting them globally
- Added regression tests for route-specific CSP, default CSP, and route-specific Cache-Control behavior

## Why

The `/docs` route sets a custom `Content-Security-Policy` header with a hash for the inline Swagger UI initialization script. The previous global security headers middleware always set the default CSP after route handling, which could overwrite route-specific CSP headers and block Swagger UI initialization.

This change keeps the existing default security headers while preserving route-level overrides when a route intentionally sets its own CSP or Cache-Control policy.

## Testing

- [x] `pnpm exec vitest run tests/security-headers.test.ts`
- [x] `pnpm build`
- [ ] `pnpm test`

Full `pnpm test` currently fails in `tests/routes/stats.test.ts`. I confirmed the same `stats.test.ts` failure on the current `main` branch, so it appears unrelated to this CSP/security headers change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for security header validation, ensuring proper handling across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->