### PR TITLE
fix(api,#186): bound funding-history scan (DB LIMIT + cache)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",
-    "@percolator/shared": "github:dcccrypto/percolator-shared#3dfbb7eeb689c8800c6324b89f4104f98b95b699",
+    "@percolator/shared": "github:dcccrypto/percolator-shared#489f5b48b6d7826ce62bae6734bb3d078c392730",
     "@percolatorct/sdk": "file:../../percolator-sdk",
     "@sentry/node": "^10.39.0",
     "@solana/web3.js": "^1.98.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.19.11
         version: 1.19.11(hono@4.12.9)
       '@percolator/shared':
-        specifier: github:dcccrypto/percolator-shared#3dfbb7eeb689c8800c6324b89f4104f98b95b699
-        version: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/3dfbb7eeb689c8800c6324b89f4104f98b95b699(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: github:dcccrypto/percolator-shared#489f5b48b6d7826ce62bae6734bb3d078c392730
+        version: '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/489f5b48b6d7826ce62bae6734bb3d078c392730(@percolatorct/sdk@file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)'
       '@percolatorct/sdk':
         specifier: file:../../percolator-sdk
         version: file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -446,18 +446,15 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/3dfbb7eeb689c8800c6324b89f4104f98b95b699':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/3dfbb7eeb689c8800c6324b89f4104f98b95b699}
-    version: 0.1.0
-
   '@percolatorct/sdk@file:../../percolator-sdk':
     resolution: {directory: ../../percolator-sdk, type: directory}
     engines: {node: '>=20.0.0'}
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/e666fd9a23139f5bb9cd3c148832358f874232f6':
-    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/e666fd9a23139f5bb9cd3c148832358f874232f6}
-    version: 2.2.0-beta.1
-    engines: {node: '>=20.0.0'}
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/489f5b48b6d7826ce62bae6734bb3d078c392730':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/489f5b48b6d7826ce62bae6734bb3d078c392730}
+    version: 1.0.0-beta.8
+    peerDependencies:
+      '@percolatorct/sdk': '>=2.0.5'
 
   '@prisma/instrumentation@7.2.0':
     resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
@@ -1296,6 +1293,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -1675,24 +1684,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
 
-  '@percolator/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/3dfbb7eeb689c8800c6324b89f4104f98b95b699(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@percolator/sdk': '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/e666fd9a23139f5bb9cd3c148832358f874232f6(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)'
-      '@sentry/node': 10.40.0
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@supabase/supabase-js': 2.97.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      bs58: 6.0.0
-      dotenv: 16.6.1
-      tweetnacl: 1.0.3
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@percolatorct/sdk@file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -1704,14 +1695,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/e666fd9a23139f5bb9cd3c148832358f874232f6(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@percolatorct/shared@https://codeload.github.com/dcccrypto/percolator-shared/tar.gz/489f5b48b6d7826ce62bae6734bb3d078c392730(@percolatorct/sdk@file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@percolatorct/sdk': file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@sentry/node': 10.40.0
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@supabase/supabase-js': 2.97.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      bs58: 6.0.0
+      dotenv: 16.6.1
+      tweetnacl: 1.0.3
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 4.3.6
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - fastestsmallesttextencoderdecoder
+      - supports-color
       - typescript
       - utf-8-validate
 
@@ -2558,6 +2556,11 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10

--- a/src/routes/funding.ts
+++ b/src/routes/funding.ts
@@ -257,7 +257,7 @@ export function fundingRoutes(): Hono {
    *
    * GH#36
    */
-  app.get("/funding/:slab/historySince", validateSlab, async (c) => {
+  app.get("/funding/:slab/historySince", cacheMiddleware(30), validateSlab, async (c) => {
     const slab = c.req.param("slab");
     if (!slab) return c.json({ error: "slab required" }, 400);
 
@@ -308,9 +308,12 @@ export function fundingRoutes(): Hono {
     }
 
     try {
-      let history = await getFundingHistorySince(slab, validatedSince);
+      // #186: pass the row cap to the query so the DB bounds the read (LIMIT) instead of
+      // materializing the entire matching set and trimming in JS. The slice below is now
+      // a defensive no-op.
+      let history = await getFundingHistorySince(slab, validatedSince, limit);
 
-      // Enforce row cap
+      // Enforce row cap (defensive — the query already applies LIMIT)
       if (history.length > limit) {
         history = history.slice(0, limit);
       }
@@ -360,7 +363,7 @@ export function fundingRoutes(): Hono {
    * - limit: number of records (default 100, max 1000)
    * - since: ISO timestamp (default: 24h ago)
    */
-  app.get("/funding/:slab/history", validateSlab, async (c) => {
+  app.get("/funding/:slab/history", cacheMiddleware(30), validateSlab, async (c) => {
     const slab = c.req.param("slab");
     if (!slab) return c.json({ error: "slab required" }, 400);
     const limitParam = c.req.query("limit");
@@ -396,8 +399,10 @@ export function fundingRoutes(): Hono {
           }
           validatedSince = d.toISOString();
         }
-        history = await getFundingHistorySince(slab, validatedSince);
-        // PERC-8178: Enforce row cap on since-based queries
+        // #186: bound the DB read (LIMIT MAX_ROWS) so a far-past `since` can't force a full
+        // per-slab scan + full materialization; the slice below is now a defensive no-op.
+        history = await getFundingHistorySince(slab, validatedSince, MAX_ROWS);
+        // PERC-8178: Enforce row cap on since-based queries (defensive — query applies LIMIT)
         if (history.length > MAX_ROWS) {
           history = history.slice(0, MAX_ROWS);
         }

--- a/tests/routes/funding.test.ts
+++ b/tests/routes/funding.test.ts
@@ -341,7 +341,7 @@ describe("funding routes", () => {
       const app = fundingRoutes();
       await app.request("/funding/11111111111111111111111111111111/history?since=2025-01-01T00:00:00Z");
 
-      expect(getFundingHistorySince).toHaveBeenCalledWith("11111111111111111111111111111111", "2025-01-01T00:00:00.000Z");
+      expect(getFundingHistorySince).toHaveBeenCalledWith("11111111111111111111111111111111", "2025-01-01T00:00:00.000Z", expect.any(Number));
     });
 
     it("should accept unix epoch seconds as since param (PERC-8178)", async () => {
@@ -351,7 +351,7 @@ describe("funding routes", () => {
       // 1704067200 = 2024-01-01T00:00:00Z
       await app.request("/funding/11111111111111111111111111111111/history?since=1704067200");
 
-      expect(getFundingHistorySince).toHaveBeenCalledWith("11111111111111111111111111111111", "2024-01-01T00:00:00.000Z");
+      expect(getFundingHistorySince).toHaveBeenCalledWith("11111111111111111111111111111111", "2024-01-01T00:00:00.000Z", expect.any(Number));
     });
 
     it("should accept unix epoch milliseconds as since param (PERC-8178)", async () => {
@@ -361,7 +361,7 @@ describe("funding routes", () => {
       // 1704067200000 = 2024-01-01T00:00:00Z
       await app.request("/funding/11111111111111111111111111111111/history?since=1704067200000");
 
-      expect(getFundingHistorySince).toHaveBeenCalledWith("11111111111111111111111111111111", "2024-01-01T00:00:00.000Z");
+      expect(getFundingHistorySince).toHaveBeenCalledWith("11111111111111111111111111111111", "2024-01-01T00:00:00.000Z", expect.any(Number));
     });
 
     it("should return 400 for invalid since param (PERC-8178)", async () => {
@@ -635,7 +635,8 @@ describe("funding routes", () => {
       });
       expect(vi.mocked(getFundingHistorySince)).toHaveBeenCalledWith(
         VALID_SLAB,
-        new Date(VALID_SINCE).toISOString()
+        new Date(VALID_SINCE).toISOString(),
+        expect.any(Number)
       );
     });
 


### PR DESCRIPTION
Part 2 of #186. Passes the row cap to `getFundingHistorySince` (now DB-side `LIMIT` via the bumped @percolator/shared pin) so a far-past `since` can't force a full per-slab scan, and adds `cacheMiddleware(30)` to `/historySince` + `/history`. 270 tests pass. Closes #186.