### PR TITLE
test(api): align buildAdlInstruction sdk-smoke assertion with the real v17 message

### DIFF
--- a/tests/sdk-smoke.test.ts
+++ b/tests/sdk-smoke.test.ts
@@ -330,7 +330,7 @@ describe("@percolatorct/sdk v17 — removed instruction guards", () => {
     // + its own ranking logic. This test documents the v17 behavior.
     expect(() =>
       buildAdlInstruction(DUMMY_KEY, DUMMY_KEY, DUMMY_KEY, DUMMY_KEY, 0)
-    ).toThrow("not in v17");
+    ).toThrow("ExecuteAdl transaction building is not supported");
   });
 
   it("encodePermissionlessCrank is a function and hardcodes fundingRateE9=0n on-wire", () => {


### PR DESCRIPTION
The buildAdlInstruction throw is correct (ExecuteAdl removed from the v17 wrapper); only the test's expected substring was stale. 295 tests pass.