### PR TITLE
fix(api): throttle per-IP RPC-fetch fan-out on /api/adl/rankings [BUG-001]

### DIFF
--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -42,7 +42,7 @@ function normalizeIp(ip: string): string {
   return ip;
 }
 
-function getClientIp(c: Context): string | null {
+export function getClientIp(c: Context): string | null {
   if (PROXY_DEPTH === 0) {
     // No trusted proxy: ignore all forwarded headers, use socket address.
     // x-real-ip is client-spoofable and must not be trusted without a proxy.

--- a/src/routes/adl.ts
+++ b/src/routes/adl.ts
@@ -54,6 +54,8 @@ import {
 import { withRpcFallback } from "../utils/rpc-fallback.js";
 import { RpcTimeoutError } from "../utils/rpc-timeout.js";
 import { isBlockedSlab } from "../middleware/validateSlab.js";
+import { getClientIp } from "../middleware/rate-limit.js";
+import { getSharedStore } from "../middleware/shared-store.js";
 
 const logger = createLogger("api:adl");
 
@@ -61,6 +63,26 @@ const logger = createLogger("api:adl");
 const ADL_CACHE_TTL_MS = 15_000; // 15 seconds
 const ADL_CACHE_MAX_ENTRIES = 100;
 const adlCache = new Map<string, { data: any; fetchedAt: number }>();
+
+// ─── per-IP RPC-fetch throttle ──────────────────────────────────────────────
+// The cache above only de-dupes repeated lookups of the SAME slab. It does
+// nothing to stop a caller from cycling through many distinct slab values
+// (real or syntactically-valid-but-nonexistent) to force a fresh fetchSlab
+// RPC call per request. This throttle counts only cache-miss-triggering
+// fetches per IP, so normal polling of a handful of real markets within the
+// cache TTL is unaffected, while distinct-slab cycling is capped.
+const ADL_RPC_FETCH_WINDOW_MS = 60_000; // 1 minute
+const ADL_RPC_FETCH_MAX_ENTRIES = 50_000; // same OOM-safety cap as rate-limit.ts
+const ADL_RPC_FETCH_LIMIT = (() => {
+  const parsed = Number(process.env.ADL_RPC_FETCH_LIMIT_PER_MIN ?? "20");
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    logger.warn("Invalid ADL_RPC_FETCH_LIMIT_PER_MIN, using default 20", {
+      value: process.env.ADL_RPC_FETCH_LIMIT_PER_MIN,
+    });
+    return 20;
+  }
+  return parsed;
+})();
 
 /** @internal Reset cache — used by tests to ensure isolation */
 export function __resetAdlCache(): void {
@@ -198,6 +220,25 @@ export function adlRoutes(): Hono {
 
     if (isBlockedSlab(slab)) {
       return c.json({ error: "Market not found" }, 404);
+    }
+
+    // Throttle cache-miss-triggering RPC fetches per IP. This is what actually
+    // bounds RPC-cost amplification from cycling distinct slab values; the
+    // generic global rate limiter alone does not, since each distinct slab is
+    // a fresh cache miss regardless of how many total requests remain in budget.
+    const ip = getClientIp(c);
+    if (ip) {
+      const bucket = await getSharedStore().incrementRateBucket(
+        `adl-rpc-fetch:${ip}`,
+        ADL_RPC_FETCH_WINDOW_MS,
+        ADL_RPC_FETCH_MAX_ENTRIES
+      );
+      if (bucket.count > ADL_RPC_FETCH_LIMIT) {
+        const retryAfter = Math.max(1, Math.floor((bucket.resetAt - Date.now()) / 1000));
+        c.header("Retry-After", retryAfter.toString());
+        logger.warn("ADL RPC-fetch throttle exceeded", { ip, slab, limit: ADL_RPC_FETCH_LIMIT });
+        return c.json({ error: "Too many distinct market lookups — try again shortly" }, 429);
+      }
     }
 
     let data: Uint8Array;

--- a/tests/routes/adl.test.ts
+++ b/tests/routes/adl.test.ts
@@ -2,7 +2,9 @@
  * Tests for ADL rankings route — PERC-8293 (T11)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair } from "@solana/web3.js";
 import { adlRoutes, __resetAdlCache } from "../../src/routes/adl.js";
+import { resetSharedStore, InMemoryStore } from "../../src/middleware/shared-store.js";
 
 // ── mocks ──────────────────────────────────────────────────────────────────
 
@@ -55,10 +57,14 @@ function makeConfig(overrides: Partial<Record<string, unknown>> = {}): Record<st
   };
 }
 
-async function makeRequest(queryString: string) {
+async function makeRequest(queryString: string, headers: Record<string, string> = {}) {
   const app = adlRoutes();
-  const req = new Request(`http://localhost/api/adl/rankings${queryString}`);
+  const req = new Request(`http://localhost/api/adl/rankings${queryString}`, { headers });
   return app.fetch(req);
+}
+
+function distinctValidSlabs(n: number): string[] {
+  return Array.from({ length: n }, () => Keypair.generate().publicKey.toBase58());
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
@@ -271,5 +277,54 @@ describe("GET /api/adl/rankings", () => {
     for (const field of requiredFields) {
       expect(body).toHaveProperty(field);
     }
+  });
+
+  describe("per-IP RPC-fetch throttle (BUG-001)", () => {
+    beforeEach(() => {
+      resetSharedStore(new InMemoryStore());
+    });
+
+    it("returns 429 after exceeding the distinct-slab fetch limit for one IP", async () => {
+      const ip = "203.0.113.50";
+      const slabs = distinctValidSlabs(21); // default limit is 20/min
+      let lastRes;
+      for (const slab of slabs) {
+        lastRes = await makeRequest(`?slab=${slab}`, { "x-forwarded-for": ip });
+      }
+      expect(lastRes!.status).toBe(429);
+      const body = await lastRes!.json();
+      expect(body.error).toMatch(/too many/i);
+    });
+
+    it("does not count cache hits toward the throttle", async () => {
+      const ip = "203.0.113.51";
+      // Repeated requests for the SAME slab should be cache hits after the
+      // first and never trip the distinct-slab throttle, even past its limit.
+      for (let i = 0; i < 30; i++) {
+        const res = await makeRequest(`?slab=${VALID_SLAB}`, { "x-forwarded-for": ip });
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it("tracks separate throttle buckets per IP", async () => {
+      const slabsA = distinctValidSlabs(20);
+      const slabsB = distinctValidSlabs(20);
+      for (const slab of slabsA) {
+        const res = await makeRequest(`?slab=${slab}`, { "x-forwarded-for": "203.0.113.60" });
+        expect(res.status).not.toBe(429);
+      }
+      for (const slab of slabsB) {
+        const res = await makeRequest(`?slab=${slab}`, { "x-forwarded-for": "203.0.113.61" });
+        expect(res.status).not.toBe(429);
+      }
+    });
+
+    it("does not throttle when client IP cannot be determined", async () => {
+      // No x-forwarded-for header and no real socket in the test harness —
+      // getClientIp() returns null, so the route falls through unthrottled
+      // (the global app-level rate limiter is the authoritative IP gate).
+      const res = await makeRequest(`?slab=${VALID_SLAB}`);
+      expect(res.status).toBe(200);
+    });
   });
 });


### PR DESCRIPTION
## Problem
`GET /api/adl/rankings` caches results per slab address (15s TTL, `src/routes/adl.ts:61-65`), which de-dupes repeated lookups of the *same* market. It does nothing to stop a caller cycling through many distinct slab values — real market addresses (public via `/markets`) or syntactically-valid-but-nonexistent ones — to force a fresh `fetchSlab` RPC call per request. The only existing bound is the generic 100 req/min/IP global rate limit, which still permits up to 100 fresh RPC reads/minute/IP through this single endpoint.

## Impact
RPC-cost amplification / availability risk against the configured Solana RPC provider: a single IP (or small botnet) can sustain ~100 RPC calls/min by varying the `slab` query param, well above what a normal client needs (polling a handful of real markets). On a metered RPC plan this is a direct cost-DoS vector; on a shared provider it risks rate-limiting/degrading RPC access for all other endpoints in the same process.

## Fix
Added a dedicated per-IP throttle on cache-miss-triggering RPC fetches only (`src/routes/adl.ts`), separate from the existing per-slab result cache:
- Default 20 fresh fetches/min/IP, env-tunable via `ADL_RPC_FETCH_LIMIT_PER_MIN` (same validation pattern as the existing `ADL_INSURANCE_UTIL_THRESHOLD_BPS` tunable in this file).
- Counts only cache misses (i.e. the expensive path), so normal polling of a handful of real markets within the 15s cache TTL is completely unaffected.
- Reuses the existing multi-replica-safe `SharedStore` (`getSharedStore().incrementRateBucket`) — the same backend the global rate limiter already uses — so the cap holds across horizontally-scaled replicas rather than being trivially bypassed by replica-cycling.
- Exported `getClientIp` from `src/middleware/rate-limit.ts` (was already implemented there with proxy-spoofing protection) instead of duplicating IP-resolution logic.
- When client IP can't be resolved (e.g. no trusted proxy configured and no socket info), the throttle no-ops rather than failing closed — the global app-level rate limiter is already the authoritative IP-presence gate for the whole app.

## Proof of Fix
- New tests demonstrate: (1) the 21st distinct-slab fetch from one IP within the window returns 429, (2) repeated requests to the *same* slab never trip the throttle even past the limit (cache hits are free), (3) separate IPs get independent budgets, (4) requests where IP can't be resolved still succeed.
- All existing tests pass — output attached.
- `tsc --noEmit` clean (this repo has no separate lint script).

## Test Output
```
✓ tests/routes/adl.test.ts (14 tests) 249ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Full suite: 298/299 passed. The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated to this change — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit; no existing open issue/PR covers this endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-IP throttling for ADL cache-miss fetch requests, with a `429` response and `Retry-After` header when the limit is exceeded.
  * Requests from the same IP now have separate rate limits from other IPs.

* **Bug Fixes**
  * Repeated requests for the same slab no longer count toward the distinct-fetch throttle.

* **Tests**
  * Expanded route coverage for throttling, cache-hit behavior, per-IP limits, and missing IP detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->