### PR TITLE
fix(api): per-client try/catch in WS broadcast loops to prevent fan-out abort [BUG-002]

### DIFF
--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -202,7 +202,7 @@ const metrics: Metrics = {
 };
 
 /**
- * Safely send a JSON-serializable payload to a WebSocket client.
+ * Guarded send of an already-serialized payload to a WebSocket client.
  *
  * The async message handler runs concurrently per message and contains
  * `await`s, so the underlying socket can transition out of OPEN between
@@ -215,24 +215,33 @@ const metrics: Metrics = {
  *   2. Honour `bufferedAmount <= MAX_BUFFER_BYTES` for backpressure.
  *   3. Catch any residual TOCTOU race where the socket closes between
  *      the check and the send call itself, logging it as debug rather
- *      than letting the error escape the handler.
+ *      than letting the error escape the caller — critically, this must
+ *      be per-client: broadcast loops fan one message out to many clients,
+ *      and one client's send throwing must not abort the rest of the loop.
  *
  * On a successful send, metrics are bumped so observability stays
  * accurate without callers having to remember to do it themselves.
+ *
+ * Takes a pre-serialized string so broadcast loops that fan the same
+ * message out to many clients only pay the JSON.stringify cost once.
  */
-function safeSend(ws: WebSocket, payload: unknown): void {
+function sendSerialized(ws: WebSocket, serialized: string): void {
   if (ws.readyState !== WebSocket.OPEN) return;
   if (ws.bufferedAmount > MAX_BUFFER_BYTES) return;
-  const serialized = JSON.stringify(payload);
   try {
     ws.send(serialized);
     metrics.messagesSent++;
     metrics.bytesSent += serialized.length;
   } catch (err) {
-    logger.debug("safeSend dropped after socket transitioned out of OPEN", {
+    logger.debug("sendSerialized dropped after socket transitioned out of OPEN", {
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+/** Safely send a JSON-serializable payload to a single WebSocket client. */
+function safeSend(ws: WebSocket, payload: unknown): void {
+  sendSerialized(ws, JSON.stringify(payload));
 }
 
 // Reset rate metrics every minute for messages/sec and bytes/sec
@@ -434,14 +443,8 @@ function flushPriceUpdate(slabAddress: string): void {
     });
     
     for (const client of slabClients) {
-      if (
-        client.ws.readyState === WebSocket.OPEN &&
-        client.subscriptions.has(channel)
-      ) {
-        if (client.ws.bufferedAmount > MAX_BUFFER_BYTES) continue;
-        client.ws.send(msg);
-        metrics.messagesSent++;
-        metrics.bytesSent += msg.length;
+      if (client.subscriptions.has(channel)) {
+        sendSerialized(client.ws, msg);
       }
     }
   } catch (err) {
@@ -537,14 +540,8 @@ export function setupWebSocket(server: Server): WebSocketServer {
       });
 
       for (const client of slabClients) {
-        if (
-          client.ws.readyState === WebSocket.OPEN &&
-          client.subscriptions.has(channel)
-        ) {
-          if (client.ws.bufferedAmount > MAX_BUFFER_BYTES) continue;
-          client.ws.send(msg);
-          metrics.messagesSent++;
-          metrics.bytesSent += msg.length;
+        if (client.subscriptions.has(channel)) {
+          sendSerialized(client.ws, msg);
         }
       }
     } catch (err) {
@@ -570,14 +567,8 @@ export function setupWebSocket(server: Server): WebSocketServer {
       });
 
       for (const client of slabClients) {
-        if (
-          client.ws.readyState === WebSocket.OPEN &&
-          client.subscriptions.has(channel)
-        ) {
-          if (client.ws.bufferedAmount > MAX_BUFFER_BYTES) continue;
-          client.ws.send(msg);
-          metrics.messagesSent++;
-          metrics.bytesSent += msg.length;
+        if (client.subscriptions.has(channel)) {
+          sendSerialized(client.ws, msg);
         }
       }
     } catch (err) {

--- a/tests/routes/ws-broadcast-fanout.test.ts
+++ b/tests/routes/ws-broadcast-fanout.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression for BUG-002: the price/trade/funding broadcast loops in ws.ts
+ * must not abort mid-fan-out when one client's ws.send() throws. Before the
+ * fix, each loop called client.ws.send() directly with only one outer
+ * try/catch around the entire listener — a throw from an earlier client's
+ * send aborted delivery to every later client in that broadcast cycle. The
+ * fix routes all three loops through the same per-client guarded sender
+ * (sendSerialized) that safeSend() already used for the message-handler
+ * reply path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import { EventEmitter } from "node:events";
+import type { WebSocket as WS } from "ws";
+
+const sharedEventBus = new EventEmitter();
+
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  eventBus: sharedEventBus,
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          abortSignal: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+          })),
+          single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+        })),
+      })),
+    })),
+  })),
+  sanitizeSlabAddress: vi.fn((s: string) => s),
+  sendInfoAlert: vi.fn(),
+}));
+
+interface TestServer {
+  server: http.Server;
+  port: number;
+  WebSocketCtor: typeof WS;
+}
+
+async function startServer(): Promise<TestServer> {
+  Object.assign(process.env, { NODE_ENV: "test", WS_AUTH_REQUIRED: "false" });
+  vi.resetModules();
+  const { setupWebSocket } = await import("../../src/routes/ws.js");
+  // Import "ws" only AFTER ws.ts has resolved it, so both the test's client
+  // sockets and the server's internal sockets share the same module
+  // instance — required for prototype.send spying below to reach both.
+  const { WebSocket: WebSocketCtor } = await import("ws");
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+  setupWebSocket(server as unknown as import("node:http").Server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as { port: number };
+  return { server, port, WebSocketCtor };
+}
+
+function stopServer(ts: TestServer): Promise<void> {
+  return new Promise((resolve, reject) =>
+    ts.server.close((err) => (err ? reject(err) : resolve())),
+  );
+}
+
+function waitForOpen(ws: WS): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === ws.OPEN) return resolve();
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+}
+
+function waitForClose(ws: WS): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === ws.CLOSED) return resolve();
+    ws.once("close", () => resolve());
+  });
+}
+
+function waitForSubscribed(ws: WS): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("timeout waiting for subscribed ack")), 1500);
+    const onMsg = (raw: unknown) => {
+      const parsed = JSON.parse(String(raw));
+      if (parsed.type === "subscribed") {
+        clearTimeout(timer);
+        ws.off("message", onMsg);
+        resolve(parsed);
+      }
+    };
+    ws.on("message", onMsg);
+  });
+}
+
+describe("WS broadcast fan-out — safeSend hardening (BUG-002)", () => {
+  let ts: TestServer;
+  let uncaughtErrors: unknown[] = [];
+  const onUncaught = (err: unknown) => uncaughtErrors.push(err);
+
+  beforeEach(() => {
+    uncaughtErrors = [];
+    process.on("uncaughtException", onUncaught);
+    process.on("unhandledRejection", onUncaught);
+  });
+
+  afterEach(async () => {
+    process.off("uncaughtException", onUncaught);
+    process.off("unhandledRejection", onUncaught);
+    if (ts) await stopServer(ts);
+    delete process.env.WS_AUTH_REQUIRED;
+    sharedEventBus.removeAllListeners();
+  });
+
+  it("delivers a price broadcast to a later client even when an earlier client's send throws", async () => {
+    ts = await startServer();
+    const { WebSocketCtor } = ts;
+
+    const clientA = new WebSocketCtor(`ws://127.0.0.1:${ts.port}/`);
+    const clientB = new WebSocketCtor(`ws://127.0.0.1:${ts.port}/`);
+    await Promise.all([waitForOpen(clientA), waitForOpen(clientB)]);
+
+    clientA.send(JSON.stringify({ type: "subscribe", channels: ["price:SLAB-FANOUT"] }));
+    clientB.send(JSON.stringify({ type: "subscribe", channels: ["price:SLAB-FANOUT"] }));
+    await Promise.all([waitForSubscribed(clientA), waitForSubscribed(clientB)]);
+
+    // From this point on, force the FIRST ws.send() call to throw
+    // synchronously — simulating a client whose send fails for any reason
+    // (TOCTOU readyState race, internal ws library error, etc.) — then
+    // restore normal behaviour for every subsequent call. Client sockets
+    // were created from the same module instance as the server's internal
+    // sockets (see startServer), so this reaches both.
+    const originalSend = WebSocketCtor.prototype.send;
+    let sendCalls = 0;
+    const sendSpy = vi
+      .spyOn(WebSocketCtor.prototype, "send")
+      .mockImplementation(function (this: WS, ...args: unknown[]) {
+        sendCalls++;
+        if (sendCalls === 1) {
+          throw new Error("simulated send failure on first client");
+        }
+        return (originalSend as (...a: unknown[]) => void).apply(this, args);
+      });
+
+    const clientBMessage = new Promise<any>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("clientB never received the broadcast")), 2000);
+      clientB.once("message", (raw) => {
+        clearTimeout(timer);
+        resolve(JSON.parse(String(raw)));
+      });
+    });
+
+    sharedEventBus.emit("price.updated", {
+      slabAddress: "SLAB-FANOUT",
+      data: { priceE6: 1_500_000 },
+      timestamp: Date.now(),
+    });
+
+    const received = await clientBMessage;
+    expect(received.type).toBe("price");
+    expect(received.slab).toBe("SLAB-FANOUT");
+    // The spy must actually have been exercised at least twice: once for the
+    // simulated failure, once for the successful delivery to clientB.
+    expect(sendCalls).toBeGreaterThanOrEqual(2);
+    expect(uncaughtErrors).toEqual([]);
+
+    sendSpy.mockRestore();
+    clientA.terminate();
+    clientB.terminate();
+    await Promise.all([waitForClose(clientA), waitForClose(clientB)]);
+  });
+});


### PR DESCRIPTION
## Problem
`flushPriceUpdate`, `tradeExecutedListener`, and `fundingUpdatedListener` in `src/routes/ws.ts` each iterate subscribed clients and call `client.ws.send(msg)` directly, guarded only by one outer `try/catch` wrapping the *entire* listener function — there is no per-client `try/catch` around the send call itself.

`safeSend()` already exists in this same file specifically to guard this exact class of failure (TOCTOU race where the socket transitions out of `OPEN` between the `readyState` check and the synchronous `send()` call, or any other `ws`-library-internal send error) — but it was only ever wired into the inbound message-handler reply path, never into these three broadcast loops.

## Impact
If `send()` throws for any one client mid-broadcast (readyState race, or any other internal error), the exception propagates out of the `for` loop entirely. The outer `try/catch` catches it at the listener level, logs, and returns — but every client later in `Set` iteration order for that broadcast cycle silently never receives that price/trade/funding update. Neither the failing client nor the skipped clients see any error; they just silently miss live data. This gets more likely to actually matter as a slab's subscriber count approaches `MAX_CONNECTIONS_PER_SLAB` (100), since each additional subscriber is another chance for one `send()` to throw and starve the rest of that cycle.

## Fix
Extracted the guarded-send logic already in `safeSend()` into a lower-level `sendSerialized(ws, serialized: string)`, operating on an already-serialized string. `safeSend(ws, payload)` now just does `JSON.stringify` once and delegates to it. All three broadcast loops (`flushPriceUpdate`, `tradeExecutedListener`, `fundingUpdatedListener`) now call `sendSerialized(client.ws, msg)` per client instead of inlining the `readyState`/`bufferedAmount` checks and a bare `client.ws.send(msg)`. Since these loops already serialize the message once outside the loop (it's identical for every subscriber), `sendSerialized` taking a pre-serialized string avoids re-stringifying per client.

This is a minimal, behavior-preserving refactor for working clients — the same `readyState`/backpressure checks run, metrics are still bumped identically on success. The only behavior change is that a throw from one client's `send()` is now caught and logged per-client instead of aborting the rest of the broadcast.

## Proof of Fix
New test (`tests/routes/ws-broadcast-fanout.test.ts`) connects two real WS clients subscribed to the same price channel, forces the *first* `ws.send()` call after subscribing to throw (simulating any send failure), and asserts the *second* client still receives the broadcast with no uncaught exception escaping the process.

I verified this is a genuine regression test, not a tautology: temporarily reverting just the `ws.ts` change and rerunning the test reproduces the bug exactly — `clientB never received the broadcast` — confirming the test fails on the old code and passes on the fix.

- All existing tests pass — output attached.
- New regression test passes against the fix, fails against pre-fix code (verified locally, not just asserted).
- `tsc --noEmit` clean (no separate lint script in this repo).

## Test Output
```
✓ tests/routes/ws-broadcast-fanout.test.ts (1 test) 884ms
  ✓ delivers a price broadcast to a later client even when an earlier client's send throws
```

Full suite: 295/296 passed (294 baseline + 1 new). The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit; no existing open issue/PR covers this.