### PR TITLE
fix(api): surface stale flag in JSON response body, not just headers [BUG-003]

### DIFF
--- a/src/routes/crank.ts
+++ b/src/routes/crank.ts
@@ -34,7 +34,7 @@ export function crankStatusRoutes(): Hono {
       return result;
     }
 
-    return c.json({ markets: result.data });
+    return c.json({ markets: result.data, stale: result.stale });
   });
 
   return app;

--- a/src/routes/funding.ts
+++ b/src/routes/funding.ts
@@ -109,7 +109,7 @@ export function fundingRoutes(): Hono {
     // already set on the context by the middleware.
     if (result instanceof Response) return result;
 
-    return c.json(result.data);
+    return c.json({ ...result.data, stale: result.stale });
   });
 
   /**

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -86,7 +86,7 @@ export function marketRoutes(): Hono {
       return result;
     }
 
-    return c.json({ markets: result.data });
+    return c.json({ markets: result.data, stale: result.stale });
   });
 
   // GET /markets/stats — all market stats from DB (filtered by network)
@@ -109,7 +109,7 @@ export function marketRoutes(): Hono {
       return result;
     }
 
-    return c.json({ stats: result.data });
+    return c.json({ stats: result.data, stale: result.stale });
   });
 
   // GET /markets/:slab/stats — single market stats from DB

--- a/src/routes/prices.ts
+++ b/src/routes/prices.ts
@@ -45,7 +45,7 @@ export function priceRoutes(): Hono {
       return result;
     }
 
-    return c.json({ markets: result.data });
+    return c.json({ markets: result.data, stale: result.stale });
   });
 
   app.get("/prices/:slab", validateSlab, async (c) => {

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -103,7 +103,7 @@ export function statsRoutes(): Hono {
       return result;
     }
 
-    return c.json(result.data);
+    return c.json({ ...result.data, stale: result.stale });
   });
 
   return app;

--- a/tests/routes/markets.test.ts
+++ b/tests/routes/markets.test.ts
@@ -365,4 +365,75 @@ describe("markets routes", () => {
       expect(data.error).toBe("Market not found");
     });
   });
+
+  describe("DB cache fallback — stale flag in response body (BUG-003)", () => {
+    it("surfaces stale:true in the JSON body on /markets when serving cached data after a DB failure", async () => {
+      const mockMarketsWithStats = [
+        {
+          slab_address: "11111111111111111111111111111111",
+          mint_address: "TokenMint111111111111111111111111",
+          symbol: "BTC-PERP",
+          name: "Bitcoin Perpetual",
+          decimals: 9,
+          deployer: "Deployer11111111111111111111111111",
+          oracle_authority: "Oracle111111111111111111111111111",
+          initial_price_e6: 50000000000,
+          max_leverage: 10,
+          trading_fee_bps: 5,
+          lp_collateral: "1000000000",
+          matcher_context: null,
+          status: "active",
+          logo_url: null,
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+          total_open_interest: "5000000000",
+          total_accounts: 100,
+          last_crank_slot: 123456789,
+          last_price: 50000,
+          mark_price: 50000,
+          index_price: 50000,
+          funding_rate: 5,
+          net_lp_pos: "1000000",
+        },
+      ];
+
+      let call = 0;
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === "markets_with_stats") {
+          const chainable: any = {
+            eq: vi.fn().mockReturnThis(),
+            not: vi.fn(() => {
+              call++;
+              return call === 1
+                ? Promise.resolve({ data: mockMarketsWithStats, error: null })
+                : Promise.resolve({ data: null, error: new Error("DB down") });
+            }),
+          };
+          return { select: vi.fn(() => chainable) };
+        }
+        return mockSupabase;
+      });
+
+      const app = marketRoutes();
+
+      // First request succeeds and seeds the DB-fallback cache.
+      const seedRes = await app.request("/markets");
+      expect(seedRes.status).toBe(200);
+      const seedBody = await seedRes.json();
+      expect(seedBody.stale).toBe(false);
+      expect(seedBody.markets).toHaveLength(1);
+
+      // Second request: the query fails, so withDbCacheFallback serves the
+      // cached entry. Before the fix, stale was set on headers only and
+      // silently dropped from the JSON body — a client that only reads the
+      // body (e.g. a bot or keeper) had no way to know the data was stale.
+      const res = await app.request("/markets");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-Cache-Status")).toBe("stale-fallback");
+      const body = await res.json();
+      expect(body.stale).toBe(true);
+      expect(body.markets).toHaveLength(1);
+      expect(body.markets[0].slabAddress).toBe("11111111111111111111111111111111");
+    });
+  });
 });


### PR DESCRIPTION
## Problem
`withDbCacheFallback` (`src/middleware/db-cache-fallback.ts`) computes `stale: boolean` correctly and sets HTTP staleness headers (`X-Cache-Status`, `X-Cache-Age`, `Warning`) when it serves cached data after a DB query failure. But every call site discarded `result.stale` when building the JSON response body:

- `src/routes/markets.ts` — `/markets` and `/markets/stats`
- `src/routes/crank.ts` — `/crank/status`
- `src/routes/prices.ts` — `/prices/markets`
- `src/routes/funding.ts` — `/funding/global`
- `src/routes/stats.ts` — `/stats`

(The original audit cited 3 of these; while implementing the fix I found the same pattern in the other 3.)

## Impact
Any client that only reads the response body — bots, keepers, or any non-browser consumer that doesn't inspect HTTP headers — has no in-band way to know it received data up to `MAX_STALE_AGE_MS` (1 hour) old during a DB outage. It looks identical to a fresh response.

## Fix
Added `stale: result.stale` to all 6 response bodies. Purely additive — no existing field renamed or removed, so this is not a breaking change for any consumer reading the pre-existing fields (`markets`, `stats`, etc.).

## Proof of Fix
New test on `/markets`: seeds the DB-fallback cache with a successful response (`stale: false`), fails the query on the second request, and asserts the second response body has `stale: true` and the `X-Cache-Status: stale-fallback` header.

Verified this is a genuine regression test: temporarily reverted just the `markets.ts` change and reran it — failed with `expected undefined to be false` (the field was simply absent). Restored the fix and it passes.

- All existing tests pass — output attached.
- New regression test passes against the fix, fails against pre-fix code (verified locally).
- `src/` typechecks clean via `tsc --noEmit` (this repo's `tsconfig.json` only includes `src/**/*`; tests aren't in its typecheck scope, and there's no separate lint script).

## Test Output
```
✓ tests/routes/markets.test.ts (11 tests) 86ms
```

Full suite: 295/296 passed (294 baseline + 1 new). The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit; no existing open issue/PR covers this.