### PR TITLE
fix(api): scope DB stale-fallback cache keys by network [BUG-006]

### DIFF
--- a/src/middleware/db-cache-fallback.ts
+++ b/src/middleware/db-cache-fallback.ts
@@ -4,7 +4,7 @@
  * When Supabase queries fail, serve stale cached data instead of 500 errors.
  * This improves availability during DB outages or network issues.
  */
-import { createLogger, truncateErrorMessage } from "@percolator/shared";
+import { createLogger, truncateErrorMessage, getNetwork } from "@percolator/shared";
 import { Context } from "hono";
 
 const logger = createLogger("api:db-cache-fallback");
@@ -53,10 +53,17 @@ export async function withDbCacheFallback<T>(
   queryFn: () => Promise<T>,
   c: Context
 ): Promise<DbCacheResult<T> | Response> {
+  // Suffix with the active network so this fallback cache can never serve a
+  // different network's data than the live query it's backing — every live
+  // query already filters by network at the DB layer, but the bare cacheKey
+  // strings callers pass in (e.g. "markets:all") carry no network dimension
+  // on their own.
+  const networkedKey = `${cacheKey}:${getNetwork()}`;
+
   try {
     // Try the query
     const result = await queryFn();
-    
+
     // Evict oldest entries when at capacity
     while (dbCache.size >= MAX_DB_CACHE_ENTRIES) {
       const oldest = dbCache.keys().next().value;
@@ -65,7 +72,7 @@ export async function withDbCacheFallback<T>(
     }
 
     // Cache successful result
-    dbCache.set(cacheKey, {
+    dbCache.set(networkedKey, {
       data: result,
       timestamp: Date.now(),
     });
@@ -76,9 +83,9 @@ export async function withDbCacheFallback<T>(
       error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120),
       cacheKey,
     });
-    
+
     // Check if we have cached data
-    const cached = dbCache.get(cacheKey);
+    const cached = dbCache.get(networkedKey);
     
     if (cached) {
       const age = Date.now() - cached.timestamp;

--- a/tests/middleware/db-cache-fallback.test.ts
+++ b/tests/middleware/db-cache-fallback.test.ts
@@ -9,9 +9,11 @@ vi.mock("@percolator/shared", () => ({
     debug: vi.fn(),
   })),
   truncateErrorMessage: vi.fn((s: string) => s),
+  getNetwork: vi.fn(() => "devnet"),
 }));
 
 import { withDbCacheFallback, clearDbCache } from "../../src/middleware/db-cache-fallback.js";
+const { getNetwork } = await import("@percolator/shared");
 
 function makeApp(handler: (c: any) => Promise<Response>) {
   const app = new Hono();
@@ -22,6 +24,7 @@ function makeApp(handler: (c: any) => Promise<Response>) {
 describe("withDbCacheFallback", () => {
   beforeEach(() => {
     clearDbCache();
+    vi.mocked(getNetwork).mockReturnValue("devnet" as any);
   });
 
   it("returns DbCacheResult on success with stale=false and ok=true", async () => {
@@ -97,5 +100,42 @@ describe("withDbCacheFallback", () => {
     // Headers set by the middleware persist on the context and reach the client.
     expect(res.headers.get("X-Cache-Status")).toBe("stale-fallback");
     expect(res.headers.get("Warning")).toMatch(/^110 - "Response is Stale/);
+  });
+
+  it("does not serve a different network's stale cache after the configured network changes (BUG-006)", async () => {
+    // Seed the cache while serving devnet.
+    vi.mocked(getNetwork).mockReturnValue("devnet" as any);
+    const seedApp = makeApp(async (c) => {
+      const result = await withDbCacheFallback(
+        "test:network-switch",
+        async () => ({ network: "devnet-data" }),
+        c,
+      );
+      if (result instanceof Response) return result;
+      return c.json(result.data);
+    });
+    const seed = await seedApp.request("/test");
+    expect(seed.status).toBe(200);
+
+    // Simulate the deployment's configured network changing (e.g. redeploy/
+    // config flip) while the live query for the SAME bare cacheKey fails.
+    vi.mocked(getNetwork).mockReturnValue("mainnet" as any);
+    const fallbackApp = makeApp(async (c) => {
+      const result = await withDbCacheFallback(
+        "test:network-switch",
+        async () => {
+          throw new Error("DB down");
+        },
+        c,
+      );
+      if (result instanceof Response) return result;
+      return c.json(result.data);
+    });
+
+    const res = await fallbackApp.request("/test");
+    // Must NOT silently serve devnet's stale data under the mainnet
+    // context — there is no mainnet-keyed cache entry, so this must be a
+    // clean 503, not a 200 carrying the wrong network's data.
+    expect(res.status).toBe(503);
   });
 });


### PR DESCRIPTION
## Problem
`withDbCacheFallback`'s `dbCache` Map (`src/middleware/db-cache-fallback.ts`) is keyed by the bare strings each route passes in — `"markets:all"`, `"markets:stats"`, `"crank:status"`, `"prices:markets"`, `"funding:global"`, `"stats:platform"` — with no network dimension. Every *live* query these routes run already filters `.eq("network", getNetwork())`, but the fallback cache entry itself carries no record of which network's data it holds.

## Impact
If the configured network changes between the call that successfully populated a cache entry and a later call that fails (a redeploy, a config flip, or any shared-DB deployment serving multiple networks from the same process over its lifetime), `withDbCacheFallback` would serve the previously-cached network's data under the new network's request — a 200 response silently carrying the wrong network's markets/stats/funding data, with no way for the caller to detect the mismatch.

## Fix
Suffix the internal cache key with `getNetwork()` inside `withDbCacheFallback` itself (one line, applied transparently): `` `${cacheKey}:${getNetwork()}` ``. This fixes it once at the shared-utility level rather than touching all 6 call sites individually — every current and future caller gets network-scoped fallback caching automatically without needing to remember to include it themselves.

## Proof of Fix
New test: seeds the cache while `getNetwork()` returns `"devnet"`, then switches to `"mainnet"` and fails the live query under the same bare cache key. Asserts a clean 503 (no usable cache for the new network) rather than a 200 silently serving devnet's stale data.

Verified this is a genuine regression test: reverted just the source change and reran — failed with the response actually being a 200 carrying `{ network: "devnet-data" }` under the mainnet request, exactly the bug. Restored the fix and it correctly returns 503.

- All existing tests pass — output attached.
- New regression test passes against the fix, fails against pre-fix code (verified locally).
- `tsc --noEmit` clean (no separate lint script in this repo).

## Test Output
```
✓ tests/middleware/db-cache-fallback.test.ts (4 tests) 67ms
```

Full suite: 295/296 passed (294 baseline + 1 new). The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit; no existing open issue/PR covers this specific cache (distinct from #192/#199/PR #204, which address live-query and view-level network isolation, not this stale-fallback cache).