### PR TITLE
fix(api): cap /candles/:slab date-span to what MAX_BARS can hold [BUG-008]

### DIFF
--- a/src/routes/candles.ts
+++ b/src/routes/candles.ts
@@ -107,6 +107,20 @@ export function candleRoutes(): Hono {
       return c.json({ s: "error", errmsg: "Invalid from/to" }, 400);
     }
 
+    // Cap the requested span to what could actually produce MAX_BARS buckets
+    // at this resolution. Without this, the row cap below (MAX_BARS * 10)
+    // only bounds the RESULT size — the DB still has to scan/sort the full
+    // matching row set for the requested date range to find the first N in
+    // ascending order, which is unbounded for a multi-year range on a
+    // high-volume market regardless of how few rows are eventually returned.
+    const maxSpanSeconds = MAX_BARS * bucketSeconds;
+    if (toSec - fromSec > maxSpanSeconds) {
+      return c.json(
+        { s: "error", errmsg: `Requested range exceeds the maximum span for resolution '${resolution}' (${maxSpanSeconds}s)` },
+        400,
+      );
+    }
+
     try {
       const { data, error } = await getSupabase()
         .from("trades")

--- a/tests/routes/candles.test.ts
+++ b/tests/routes/candles.test.ts
@@ -97,7 +97,7 @@ describe("GET /candles/:slab", () => {
 
   it("returns no_data when trades table is empty", async () => {
     const app = candleRoutes();
-    const res = await app.request(`/candles/${SLAB}?resolution=1&from=0&to=9999999999`);
+    const res = await app.request(`/candles/${SLAB}?resolution=1&from=1745150400&to=1745150460`);
     expect(res.status).toBe(200);
     const body = await res.json() as any;
     expect(body.s).toBe("no_data");
@@ -112,7 +112,7 @@ describe("GET /candles/:slab", () => {
       error: null,
     });
     const app = candleRoutes();
-    const res = await app.request(`/candles/${SLAB}?resolution=1&from=0&to=9999999999`);
+    const res = await app.request(`/candles/${SLAB}?resolution=1&from=1745150400&to=1745150460`);
     const body = await res.json() as any;
     expect(body.s).toBe("ok");
     expect(body.t).toHaveLength(1);
@@ -130,5 +130,33 @@ describe("GET /candles/:slab", () => {
     const app = candleRoutes();
     const res = await app.request(`/candles/${SLAB}?resolution=1&from=1000&to=500`);
     expect(res.status).toBe(400);
+  });
+
+  describe("max date-span cap (BUG-008)", () => {
+    it("rejects a range wider than MAX_BARS buckets at the requested resolution, without querying the DB", async () => {
+      const app = candleRoutes();
+      // resolution=1 (60s buckets) — MAX_BARS(5000) * 60s = 300,000s max span.
+      // Request a multi-year range, far beyond that.
+      const res = await app.request(`/candles/${SLAB}?resolution=1&from=0&to=9999999999`);
+      expect(res.status).toBe(400);
+      const body = await res.json() as any;
+      expect(body.errmsg).toMatch(/exceeds the maximum span/i);
+      // The query must never have been issued for an out-of-bounds range.
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it("allows a range exactly at the max span for the requested resolution", async () => {
+      const app = candleRoutes();
+      const maxSpan = 5000 * 60; // MAX_BARS * RES_TO_SECONDS["1"]
+      const res = await app.request(`/candles/${SLAB}?resolution=1&from=1000000&to=${1000000 + maxSpan}`);
+      expect(res.status).toBe(200);
+    });
+
+    it("scales the allowed span with resolution — a multi-year range is fine at daily resolution", async () => {
+      const app = candleRoutes();
+      // resolution=1D (86400s buckets) — MAX_BARS(5000) * 1 day ≈ 13.7 years.
+      const res = await app.request(`/candles/${SLAB}?resolution=1D&from=0&to=400000000`); // ~12.7 years
+      expect(res.status).toBe(200);
+    });
   });
 });


### PR DESCRIPTION
## Problem
`GET /candles/:slab` validates `from < to` but never bounds the *span* between them. The existing protection — `.limit(MAX_BARS * 10)` (50,000 rows) on the trades query — only bounds the result size that comes back, not the work Postgres has to do to produce it: the query filters by `slab_address` + `network`, orders by `created_at` ascending, and takes the first 50,000 rows. For a multi-year requested range on a high-volume market with more historical trades than that, the DB still has to scan/sort the full matching row set for that date range to find the first 50,000 in order, regardless of how small the eventual response ends up being after bucketing.

## Fix
Added a max-span check: `MAX_BARS * bucketSeconds`. This scales with the requested resolution rather than being a flat constant — a flat cap would be wrong at either end (too restrictive for daily candles, too permissive for 1-minute candles). At 1-minute resolution the max span is ~3.5 days; at daily resolution it's ~13.7 years — both are exactly "the widest range that could still produce ≤ MAX_BARS buckets," which is the actual invariant this protects.

Two existing tests used `from=0&to=9999999999` as a "don't care about the exact range" placeholder spanning ~316 years; narrowed both to realistic windows since their actual intent was exercising basic data flow with a mocked Supabase response, not wide-range behavior.

## Proof of Fix
New tests: a multi-year range at 1-minute resolution is rejected with a 400 *before* the Supabase query is ever issued; a range exactly at the computed max span is accepted; a multi-year range at daily resolution (where it's legitimately within bounds) is accepted.

Verified this is a genuine regression test: reverted just the source change and reran — the multi-year-range test failed with a 200 instead of 400 (the query would have gone through unbounded). Restored the fix and it passes.

- All existing tests pass — output attached.
- New regression tests pass against the fix, the core one fails against pre-fix code (verified locally).
- `tsc --noEmit` clean (no separate lint script in this repo).

## Test Output
```
✓ tests/routes/candles.test.ts (12 tests) 58ms
```

Full suite: 297/298 passed (294 baseline + 3 new). The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit. Distinct from open issue #201 (`MAX_BARS` not capping the *output* bar count even with the row limit applied) — that's a separate root cause (output bucket-count bound vs. this fix's input date-span bound); both are needed, neither subsumes the other. No existing open issue/PR covers this specific date-span gap.