### PR TITLE
fix(api): stop fabricating markPrice/indexPrice in live WS price ticks [BUG-101]

### DIFF
--- a/src/services/OraclePriceBroadcaster.ts
+++ b/src/services/OraclePriceBroadcaster.ts
@@ -72,10 +72,17 @@ export class OraclePriceBroadcaster {
                 slab: row.slab_address,
                 priceE6,
               });
+              // oracle_prices carries only a single push price per row — there is
+              // no separate mark/index price in this event source. Previously this
+              // hardcoded markPriceE6/indexPriceE6 to the same oracle price, so
+              // every live WS tick reported markPrice === indexPrice === oracle
+              // price, contradicting the genuinely distinct values the same
+              // channel sends from market_stats on initial subscribe (ws.ts
+              // flushPriceUpdate's own `markPriceE6 ? ... : undefined` check
+              // already exists to omit these fields when not genuinely known —
+              // it was just never reachable because this was always truthy).
               eventBus.publish("price.updated", row.slab_address, {
                 priceE6,
-                markPriceE6: priceE6,
-                indexPriceE6: priceE6,
                 source: "oracle_prices",
                 tx_signature: row.tx_signature ?? undefined,
               });

--- a/tests/services/oracle-price-broadcaster.test.ts
+++ b/tests/services/oracle-price-broadcaster.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression for BUG-101: oracle_prices carries only a single push price per
+ * row — there is no separate mark/index price in this event source. The
+ * broadcaster must not fabricate markPriceE6/indexPriceE6 values equal to the
+ * oracle price; doing so caused every live WS price tick to report
+ * markPrice === indexPrice === oracle price, contradicting the genuinely
+ * distinct values the same channel sends on initial subscribe.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { publishSpy } = vi.hoisted(() => ({ publishSpy: vi.fn() }));
+
+vi.mock("@percolator/shared", () => ({
+  eventBus: { publish: publishSpy },
+  getSupabase: vi.fn(),
+  getNetwork: vi.fn(() => "devnet"),
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { getSupabase } from "@percolator/shared";
+import { OraclePriceBroadcaster } from "../../src/services/OraclePriceBroadcaster.js";
+
+describe("OraclePriceBroadcaster", () => {
+  let insertHandler: (payload: { new: unknown }) => void;
+  let mockChannel: any;
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    publishSpy.mockClear();
+    mockChannel = {
+      on: vi.fn((_event: string, _filter: unknown, handler: typeof insertHandler) => {
+        insertHandler = handler;
+        return mockChannel;
+      }),
+      subscribe: vi.fn((cb?: (status: string) => void) => {
+        cb?.("SUBSCRIBED");
+        return mockChannel;
+      }),
+    };
+    mockSupabase = {
+      channel: vi.fn(() => mockChannel),
+      removeChannel: vi.fn(),
+    };
+    vi.mocked(getSupabase).mockReturnValue(mockSupabase);
+  });
+
+  it("publishes price.updated WITHOUT fabricated markPriceE6/indexPriceE6 fields", async () => {
+    const broadcaster = new OraclePriceBroadcaster();
+    await broadcaster.start();
+
+    insertHandler({
+      new: {
+        slab_address: "SLAB1",
+        price_e6: "1500000",
+        timestamp: Date.now(),
+        tx_signature: "sig123",
+        network: "devnet",
+      },
+    });
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    const [event, slab, data] = publishSpy.mock.calls[0];
+    expect(event).toBe("price.updated");
+    expect(slab).toBe("SLAB1");
+    expect(data.priceE6).toBe(1500000);
+    expect(data).not.toHaveProperty("markPriceE6");
+    expect(data).not.toHaveProperty("indexPriceE6");
+  });
+
+  it("ignores a row with a non-positive or non-finite price", async () => {
+    const broadcaster = new OraclePriceBroadcaster();
+    await broadcaster.start();
+
+    insertHandler({ new: { slab_address: "SLAB1", price_e6: "0", timestamp: Date.now(), tx_signature: null, network: "devnet" } });
+    insertHandler({ new: { slab_address: "SLAB1", price_e6: "not-a-number", timestamp: Date.now(), tx_signature: null, network: "devnet" } });
+
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem
`OraclePriceBroadcaster` hardcoded `markPriceE6`/`indexPriceE6` to the same value as the single oracle push price on every `oracle_prices` INSERT. The `oracle_prices` table genuinely carries only one price per row — there's no separate mark/index price in this event source. `ws.ts`'s `flushPriceUpdate` forwards these fabricated values unchanged to every live WS subscriber.

## Impact
Every live WS price tick reported `markPrice === indexPrice === oracle price`, directly contradicting the correct, distinct values the same channel sends from `market_stats` on initial subscribe. On markets where mark/index price legitimately diverges from the oracle price (basis, funding skew), this is a real-time data-integrity bug, not just staleness — a client's first message after subscribing can show `markPrice != indexPrice`, then the very next live tick silently collapses them to equal.

## Fix
Stop publishing `markPriceE6`/`indexPriceE6` from this source entirely. `flushPriceUpdate` (`src/routes/ws.ts`) already has a `markPriceE6 ? ... : undefined` check specifically meant to omit these fields from the outgoing WS message when not genuinely known — it was just never reachable because the broadcaster always supplied a (wrong) value. No change needed in `ws.ts`: live ticks now correctly omit `markPrice`/`indexPrice` rather than reporting a fabricated one, while the initial-subscribe snapshot continues to send the correct, distinct values from `market_stats`.

I considered the alternative of having the broadcaster also query `market_stats` for genuine mark/index price on every oracle push, but that adds a DB round-trip to a high-frequency event path for values that update on a much slower cadence (crank-driven, not oracle-push-driven) — omitting the fields when not known is the more honest and lower-risk fix.

## Proof of Fix
New tests assert the published payload never carries `markPriceE6`/`indexPriceE6`, and that non-positive/non-finite prices are still correctly ignored.

Verified this is a genuine regression test: reverted just the source change and reran — failed with `markPriceE6: 1500000` present where it should be absent. Restored the fix and it passes.

- All existing tests pass — output attached.
- New tests pass against the fix, the core one fails against pre-fix code (verified locally).
- `tsc --noEmit` clean (no separate lint script in this repo).

## Test Output
```
✓ tests/services/oracle-price-broadcaster.test.ts (2 tests) 5ms
```

Full suite: 296/297 passed (294 baseline + 2 new). The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit; no existing open issue/PR covers this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed oracle price updates so they now publish only the incoming price value, avoiding incorrect duplicate mark/index prices.
  * Improved handling of invalid oracle prices by ignoring zero, non-numeric, or otherwise unusable values.

* **Tests**
  * Added regression coverage for oracle price broadcasts to confirm the correct event payload and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->