### PR TITLE
fix(api): add response caching to /insurance/:slab [BUG-106]

### DIFF
--- a/src/routes/insurance.ts
+++ b/src/routes/insurance.ts
@@ -8,6 +8,7 @@
  */
 import { Hono } from "hono";
 import { validateSlab } from "../middleware/validateSlab.js";
+import { cacheMiddleware } from "../middleware/cache.js";
 import { getSupabase, createLogger, truncateErrorMessage } from "@percolator/shared";
 
 const logger = createLogger("api:insurance");
@@ -31,7 +32,7 @@ export function insuranceRoutes(): Hono {
    *   ]
    * }
    */
-  app.get("/insurance/:slab", validateSlab, async (c) => {
+  app.get("/insurance/:slab", cacheMiddleware(15), validateSlab, async (c) => {
     const slab = c.req.param("slab");
 
     try {

--- a/tests/routes/insurance.test.ts
+++ b/tests/routes/insurance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { insuranceRoutes } from "../../src/routes/insurance.js";
+import { clearCache } from "../../src/middleware/cache.js";
 
 // Mock @percolator/shared
 vi.mock("@percolator/shared", () => ({
@@ -29,6 +30,7 @@ describe("insurance routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearCache();
 
     mockSupabase = {
       from: vi.fn(() => mockSupabase),
@@ -96,6 +98,50 @@ describe("insurance routes", () => {
       expect(data.feeRevenue).toBe("50000000");
       expect(data.totalOpenInterest).toBe("5000000000");
       expect(data.history).toHaveLength(2);
+    });
+
+    it("caches the response so a second request for the same slab does not re-query Supabase (BUG-106)", async () => {
+      const mockStats = {
+        insurance_balance: "1000000000",
+        insurance_fee_revenue: "50000000",
+        total_open_interest: "5000000000",
+      };
+      let fromCallCount = 0;
+      mockSupabase.from.mockImplementation((table: string) => {
+        fromCallCount++;
+        if (table === "market_stats") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({ data: mockStats, error: null }),
+              })),
+            })),
+          };
+        } else if (table === "insurance_history") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+        return mockSupabase;
+      });
+
+      const app = insuranceRoutes();
+      const res1 = await app.request("/insurance/5gX6nn6Jhh3Sxsb6FMvbVGdFspKT2vtdXxkWi2zwXmHp");
+      expect(res1.status).toBe(200);
+      const callsAfterFirst = fromCallCount;
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      const res2 = await app.request("/insurance/5gX6nn6Jhh3Sxsb6FMvbVGdFspKT2vtdXxkWi2zwXmHp");
+      expect(res2.status).toBe(200);
+      expect(res2.headers.get("X-Cache")).toBe("HIT");
+      // No new Supabase calls — served entirely from cache.
+      expect(fromCallCount).toBe(callsAfterFirst);
     });
 
     it("should return 404 when market not found", async () => {


### PR DESCRIPTION
## Problem
`GET /insurance/:slab` is wrapped by neither `cacheMiddleware` nor `withDbCacheFallback` — every single request, concurrent or not, runs two sequential un-batched Supabase queries (`market_stats` then `insurance_history`) with zero protection. Its sibling `/open-interest/:slab` (same query shape, same data source) already has `cacheMiddleware(15)`.

## Impact
A burst of concurrent clients hitting this endpoint (e.g. a dashboard polling insurance data for multiple markets) directly multiplies into 2N concurrent Postgres queries with no caching layer to absorb repeat/concurrent traffic, unlike every comparable route.

## Fix
Applied the identical `cacheMiddleware(15)` already used by `/open-interest/:slab`.

## Test fix needed alongside this
The existing test file didn't call `clearCache()` between tests. Several tests reuse the same slab address across different mock setups (expecting different DB responses each time) — once caching was added, the second+ test using the same path started getting the first test's cached response instead of hitting its own mock, breaking 4 unrelated tests. Added `clearCache()` to `beforeEach`, matching the convention already used in `open-interest.test.ts`.

## Proof of Fix
New test: two requests for the same slab — the second is served from cache (`X-Cache: HIT` header) with no additional Supabase calls.

Verified this is a genuine regression test: reverted just the source change and reran — failed because `X-Cache` was never set (no caching existed). Restored the fix and it passes.

- All existing tests pass — output attached.
- New regression test passes against the fix, fails against pre-fix code (verified locally).
- `tsc --noEmit` clean (no separate lint script in this repo).

## Test Output
```
✓ tests/routes/insurance.test.ts (11 tests) 64ms
```

Full suite: 295/296 passed (294 baseline + 1 new). The 1 failure (`tests/sdk-smoke.test.ts`) is pre-existing and unrelated — it asserts on an exact `@percolatorct/sdk` error-message string that has drifted from the locally-resolved SDK version in this environment.

## Related
Found during a broader API audit; no existing open issue/PR covers this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response caching for insurance slab requests, helping repeated lookups return faster.
* **Tests**
  * Added coverage to verify cached responses are served on repeat requests.
  * Updated test setup to clear cached data between cases for reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->