### PR TITLE
fix(api): surface shared-store (Redis/Upstash) liveness in /health [BUG-111]

### DIFF
--- a/src/middleware/shared-store.ts
+++ b/src/middleware/shared-store.ts
@@ -105,6 +105,18 @@ export interface SharedStore {
 
   /** Evict stale auth-failure records (best-effort; no-op on Redis). */
   evictExpiredAuthFailures(windowMs: number, banDurationMs: number): Promise<void>;
+
+  /**
+   * Liveness probe for the backing store, used by /health.
+   *
+   * InMemoryStore is trivially always healthy — it's the deliberately
+   * chosen single-replica backend, not a degraded state. UpstashStore
+   * issues a real Redis PING (no fallback masking) so operators can detect
+   * when multi-replica abuse-control guarantees have silently degraded to
+   * per-replica enforcement, instead of only finding out from scattered
+   * warning logs on individual failed calls.
+   */
+  ping(): Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +251,10 @@ export class InMemoryStore implements SharedStore {
           : now - rec.windowStart > windowMs * 2;
       if (stale) this.authFailures.delete(ip);
     }
+  }
+
+  async ping(): Promise<boolean> {
+    return true;
   }
 }
 
@@ -495,6 +511,19 @@ export class UpstashStore implements SharedStore {
 
   async evictExpiredAuthFailures(_windowMs: number, _banDurationMs: number): Promise<void> {
     // Redis TTL handles eviction automatically. No-op here.
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      const result = await this.cmd("PING");
+      return typeof result === "string" && result.toUpperCase() === "PONG";
+    } catch (err) {
+      logger.warn(
+        "UpstashStore.ping failed — Redis unreachable, abuse controls are running in per-replica fallback mode",
+        { error: err instanceof Error ? err.message : String(err) }
+      );
+      return false;
+    }
   }
 }
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -5,6 +5,7 @@ import { withRpcFallback } from "../utils/rpc-fallback.js";
 import { HEALTH_RPC_TIMEOUT_MS } from "../utils/rpc-timeout.js";
 import { getWebSocketMetrics } from "./ws.js";
 import { requireApiKey } from "../middleware/auth.js";
+import { getSharedStore } from "../middleware/shared-store.js";
 
 const logger = createLogger("api:health");
 const startTime = Date.now();
@@ -24,7 +25,7 @@ export function healthRoutes(): Hono {
     if (cachedHealth && Date.now() - cachedHealth.checkedAt < HEALTH_CACHE_TTL_MS) {
       return c.json(cachedHealth.body, cachedHealth.statusCode as 200 | 503);
     }
-    const checks: { db: boolean; rpc: boolean; ws: boolean } = { db: false, rpc: false, ws: false };
+    const checks: { db: boolean; rpc: boolean; ws: boolean; sharedStore: boolean } = { db: false, rpc: false, ws: false, sharedStore: false };
     let status: "ok" | "degraded" | "down" = "ok";
     
     // Check RPC connectivity
@@ -61,6 +62,17 @@ export function healthRoutes(): Hono {
       checks.ws = utilization < 0.95; // degraded if >95% of connection slots used
     } catch {
       checks.ws = false;
+    }
+
+    // Check the shared abuse-control store — when Upstash is configured but
+    // unreachable, rate limits/connection caps/auth bans silently degrade to
+    // per-replica enforcement. ping() surfaces that instead of leaving it to
+    // scattered warning logs (see shared-store.ts for the multi-replica
+    // rationale).
+    try {
+      checks.sharedStore = await getSharedStore().ping();
+    } catch {
+      checks.sharedStore = false;
     }
 
     // Determine overall status

--- a/tests/middleware/shared-store.test.ts
+++ b/tests/middleware/shared-store.test.ts
@@ -247,6 +247,51 @@ describe("UpstashStore — graceful fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ping() liveness probe (BUG-111)
+// ---------------------------------------------------------------------------
+
+describe("ping() liveness probe (BUG-111)", () => {
+  it("InMemoryStore.ping() is always true — it's the deliberately chosen backend", async () => {
+    const store = new InMemoryStore();
+    expect(await store.ping()).toBe(true);
+  });
+
+  it("UpstashStore.ping() returns true on a successful PONG", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([{ result: "PONG" }]), { status: 200 })
+    );
+
+    const store = new UpstashStore("https://test.upstash.io", "token");
+    expect(await store.ping()).toBe(true);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it("UpstashStore.ping() returns false (not the silent in-memory fallback) when Redis is unreachable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network unreachable"));
+
+    const store = new UpstashStore("https://test.upstash.io", "token");
+    expect(await store.ping()).toBe(false);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it("UpstashStore.ping() returns false on a non-PONG response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([{ result: null }]), { status: 200 })
+    );
+
+    const store = new UpstashStore("https://test.upstash.io", "token");
+    expect(await store.ping()).toBe(false);
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getSharedStore() singleton selection
 // ---------------------------------------------------------------------------
 

--- a/tests/routes/health.test.ts
+++ b/tests/routes/health.test.ts
@@ -9,6 +9,13 @@ vi.mock("../../src/routes/ws.js", () => ({
   })),
 }));
 
+// Mock shared store
+vi.mock("../../src/middleware/shared-store.js", () => ({
+  getSharedStore: vi.fn(() => ({
+    ping: vi.fn().mockResolvedValue(true),
+  })),
+}));
+
 // Mock @percolator/shared
 vi.mock("@percolator/shared", () => ({
   getSupabase: vi.fn(),
@@ -32,6 +39,7 @@ vi.mock("@percolator/shared", () => ({
 
 const { getConnection, getSupabase } = await import("@percolator/shared");
 const { getWebSocketMetrics } = await import("../../src/routes/ws.js");
+const { getSharedStore } = await import("../../src/middleware/shared-store.js");
 
 describe("health routes", () => {
   let mockConnection: any;
@@ -102,6 +110,7 @@ describe("health routes", () => {
     mockConnection.getSlot.mockRejectedValue(new Error("RPC error"));
     mockSupabase.select.mockRejectedValue(new Error("DB error"));
     vi.mocked(getWebSocketMetrics).mockImplementation(() => { throw new Error("WS unavailable"); });
+    vi.mocked(getSharedStore).mockReturnValue({ ping: vi.fn().mockResolvedValue(false) } as any);
 
     const app = healthRoutes();
     const res = await app.request("/health");
@@ -112,6 +121,53 @@ describe("health routes", () => {
     expect(data.checks.rpc).toBe(false);
     expect(data.checks.db).toBe(false);
     expect(data.checks.ws).toBe(false);
+    expect(data.checks.sharedStore).toBe(false);
+  });
+
+  describe("shared store health check (BUG-111)", () => {
+    it("flags sharedStore as unhealthy when ping() resolves false", async () => {
+      mockConnection.getSlot.mockResolvedValue(100);
+      mockSupabase.select.mockResolvedValue({ count: 5, error: null });
+      vi.mocked(getSharedStore).mockReturnValue({ ping: vi.fn().mockResolvedValue(false) } as any);
+
+      const app = healthRoutes();
+      const res = await app.request("/health");
+      const data = await res.json();
+      expect(data.checks.sharedStore).toBe(false);
+      expect(data.status).not.toBe("ok");
+    });
+
+    it("flags sharedStore as unhealthy when ping() throws", async () => {
+      mockConnection.getSlot.mockResolvedValue(100);
+      mockSupabase.select.mockResolvedValue({ count: 5, error: null });
+      vi.mocked(getSharedStore).mockReturnValue({
+        ping: vi.fn().mockRejectedValue(new Error("Redis unreachable")),
+      } as any);
+
+      const app = healthRoutes();
+      const res = await app.request("/health");
+      const data = await res.json();
+      expect(data.checks.sharedStore).toBe(false);
+    });
+
+    it("reports sharedStore healthy when ping() resolves true", async () => {
+      mockConnection.getSlot.mockResolvedValue(100);
+      mockSupabase.select.mockResolvedValue({ count: 5, error: null });
+      // A prior test in this file overrides the ws mock's implementation;
+      // clearAllMocks() doesn't undo that, so restore an explicit healthy
+      // value here rather than depending on test execution order.
+      vi.mocked(getWebSocketMetrics).mockReturnValue({
+        totalConnections: 0,
+        limits: { maxGlobalConnections: 1000 },
+      } as any);
+      vi.mocked(getSharedStore).mockReturnValue({ ping: vi.fn().mockResolvedValue(true) } as any);
+
+      const app = healthRoutes();
+      const res = await app.request("/health");
+      const data = await res.json();
+      expect(data.checks.sharedStore).toBe(true);
+      expect(data.status).toBe("ok");
+    });
   });
 
   it("should include uptime in response", async () => {


### PR DESCRIPTION
## Bug
`UpstashStore` is designed to fall back to an in-memory store on any Redis error, which is the right call-site behavior (a Redis outage shouldn't take the API down). But every fallback decision today is only visible via a scattered `logger.warn()` inside whichever method happened to fail. There's no operator-facing signal that the multi-replica abuse-control guarantee (rate limits, WS connection caps, auth bans — all documented at the top of `shared-store.ts`) has silently degraded to per-replica enforcement across the whole deployment. `/health` has no idea this subsystem exists.

## Fix
Add `ping(): Promise<boolean>` to the `SharedStore` interface:
- `InMemoryStore.ping()` is trivially always `true` — it's the deliberately chosen single-replica backend, not a degraded state.
- `UpstashStore.ping()` issues a real Redis `PING` and returns `false` on any failure — deliberately *not* routed through the fallback-to-memory path the other methods use, since the whole point here is to report the real backend's reachability rather than mask it.

`health.ts` now calls `getSharedStore().ping()` and reports it as a new `checks.sharedStore` field, following the same pattern as the existing `db`/`rpc`/`ws` checks.

## Test plan
- [x] Added `ping() liveness probe (BUG-111)` block to `tests/middleware/shared-store.test.ts`: `InMemoryStore` always true; `UpstashStore` true on `PONG`, false on network failure, false on a non-PONG response.
- [x] Added `shared store health check (BUG-111)` block to `tests/routes/health.test.ts`: `checks.sharedStore` flips false when `ping()` resolves false or throws, true when it resolves true; updated the existing "all checks fail" test to also mock `ping()` failing so it still exercises the true all-down case.
- [x] Verified both are genuine regressions: reverted `src/middleware/shared-store.ts` + `src/routes/health.ts` via `git stash`, confirmed all 8 new/updated tests fail against the unfixed code (missing `ping` on the interface/check), restored the fix.
- [x] Full suite passes (301/302 — the 1 pre-existing failure is unrelated to this change, in `adl.test.ts`).
- [x] `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared-store connectivity check to the health endpoint, improving visibility into service health.
  * Health responses now include shared-store status alongside existing checks.

* **Bug Fixes**
  * Health status now reflects shared-store failures as degraded or down instead of appearing fully healthy.
  * Redis-backed shared-store checks now fail safely when connectivity is lost or responses are unexpected.

* **Tests**
  * Expanded coverage for shared-store liveness and health endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->