### PR TITLE
fix(api): correct openapi.yaml drift from actual v17 responses [BUG-112]

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,6 +60,8 @@ tags:
     description: Auto-deleveraging rankings and trigger state
   - name: Chart
     description: OHLCV candlestick chart data
+  - name: Candles
+    description: Internal Percolator OHLCV candles derived from indexed trades
   - name: WebSocket
     description: WebSocket metrics and real-time data streaming
 
@@ -614,6 +616,63 @@ paths:
                 error: Upstream RPC timeout
                 slab: "ABC123..."
 
+  /candles/{slab}:
+    get:
+      tags:
+        - Candles
+      summary: Get internal OHLCV candles for a market
+      description: |
+        Returns OHLCV candlestick data bucketed in-process from indexed trades
+        in the `trades` table, following the TradingView UDF convention (the
+        same shape the frontend's Pyth Benchmarks proxy uses, so data sources
+        can be swapped without changing client-side parsing). Timestamps are
+        Unix seconds.
+      operationId: getCandles
+      parameters:
+        - $ref: '#/components/parameters/SlabAddress'
+        - name: resolution
+          in: query
+          description: |
+            Candle resolution. Maps to minutes except "1D" which buckets into
+            whole days.
+          schema:
+            type: string
+            enum: ["1", "5", "15", "60", "240", "1D"]
+            default: "1"
+        - name: from
+          in: query
+          description: Range start, Unix seconds
+          schema:
+            type: integer
+            default: 0
+        - name: to
+          in: query
+          description: Range end, Unix seconds (defaults to now)
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OHLCV candle data in UDF format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandlesResponse'
+        '400':
+          description: Invalid resolution or from/to range
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandlesResponse'
+              example:
+                s: error
+                errmsg: "Invalid from/to"
+                t: []
+                o: []
+                h: []
+                l: []
+                c: []
+                v: []
+
   /chart/{mint}:
     get:
       tags:
@@ -909,19 +968,19 @@ components:
           type: integer
           nullable: true
         lastCrankSlot:
-          type: string
+          type: integer
           nullable: true
         lastPrice:
-          type: string
+          type: number
           nullable: true
         markPrice:
-          type: string
+          type: number
           nullable: true
         indexPrice:
-          type: string
+          type: number
           nullable: true
         fundingRate:
-          type: string
+          type: number
           nullable: true
         netLpPos:
           type: string
@@ -941,13 +1000,17 @@ components:
         lp_max_abs:
           type: string
         last_price:
-          type: string
+          type: number
+          nullable: true
         mark_price:
-          type: string
+          type: number
+          nullable: true
         index_price:
-          type: string
+          type: number
+          nullable: true
         funding_rate:
-          type: string
+          type: number
+          nullable: true
         insurance_balance:
           type: string
         insurance_fee_revenue:
@@ -955,7 +1018,8 @@ components:
         volume_24h:
           type: string
         last_crank_slot:
-          type: string
+          type: integer
+          nullable: true
         updated_at:
           type: string
           format: date-time
@@ -989,6 +1053,12 @@ components:
               type: string
         engine:
           type: object
+          nullable: true
+          description: |
+            On-chain engine state. Null for v17 market-group accounts — v17
+            engine state is per-portfolio, not stored in the market-group
+            account. Clients should query /markets/{slab}/stats for indexed
+            v17 state instead.
           properties:
             vault:
               type: string
@@ -1111,13 +1181,13 @@ components:
           type: string
           format: date-time
         slot:
-          type: string
+          type: integer
         rateBpsPerSlot:
           type: number
         netLpPos:
           type: string
         priceE6:
-          type: string
+          type: number
         fundingIndexQpbE6:
           type: string
 
@@ -1273,6 +1343,43 @@ components:
         pnlPctMillionths:
           type: string
           description: PnL percentage scaled by 1,000,000 (bigint as string)
+
+    CandlesResponse:
+      type: object
+      description: TradingView UDF-style OHLCV response. Parallel arrays indexed by position.
+      properties:
+        s:
+          type: string
+          enum: [ok, no_data, error]
+          description: Status — "ok" with data, "no_data" for an empty range, "error" on failure
+        errmsg:
+          type: string
+          description: Present only when s is "error"
+        t:
+          type: array
+          items:
+            type: integer
+          description: Bar open times, Unix seconds
+        o:
+          type: array
+          items:
+            type: number
+        h:
+          type: array
+          items:
+            type: number
+        l:
+          type: array
+          items:
+            type: number
+        c:
+          type: array
+          items:
+            type: number
+        v:
+          type: array
+          items:
+            type: number
 
     ChartResponse:
       type: object


### PR DESCRIPTION
## Bug
`openapi.yaml` has drifted from the actual route implementations in four ways:

1. **Missing path**: `/candles/{slab}` (`src/routes/candles.ts`) is a live route with no entry in the spec at all.
2. **Wrong types** in `MarketWithStats`/`MarketStats`: `lastPrice`/`markPrice`/`indexPrice`/`fundingRate`/`lastCrankSlot` (and snake_case equivalents) are documented as `string`, but `markets.ts` returns them as raw numeric Postgres columns — confirmed as JS numbers via the existing mocks in `tests/routes/markets.test.ts` (e.g. `last_price: 50000`, not `"50000"`).
3. **Wrong types** in `FundingHistoryEntry`: `slot`/`priceE6` documented as `string`, but `funding.ts` passes through `h.slot`/`h.price_e6` unmodified — same numeric-column pattern, confirmed via `tests/routes/funding.test.ts` mocks (e.g. `slot: 123456789`, `price_e6: 50000000000`).
4. **Wrong nullability** in `MarketDetails.engine`: documented as a non-nullable object, but `markets.ts` explicitly returns `engine: null` for v17 market-group accounts (v17 engine state moved to per-portfolio storage, queried via `/markets/{slab}/stats` instead) — a `null` here is invalid against a non-`nullable` `object` schema for any strict validator or generated client.

Fields that are genuinely large/precision-sensitive on-chain values stored as Postgres `numeric` (`totalOpenInterest`, `netLpPos`, `lpSumAbs`, etc.) were left as `string` — those really do come back as strings to avoid float precision loss, and were already documented correctly.

## Fix
- Added the `/candles/{slab}` path with a new `CandlesResponse` schema matching the route's actual TradingView-UDF-style response shape, and a `Candles` tag.
- Changed the 5 mistyped numeric fields in `MarketWithStats` and `MarketStats` from `string` to `number`/`integer` (with `nullable: true` where the route can return `null`).
- Changed `FundingHistoryEntry.slot` to `integer` and `.priceE6` to `number`.
- Added `nullable: true` + an explanatory description to `MarketDetails.engine`.

## Test plan
This is a documentation-only change to a static YAML file served as-is by `docs.ts` — there's no associated runtime logic or existing test suite to update/revert-and-confirm against. Verified instead via:
- [x] `npx js-yaml openapi.yaml` — parses cleanly, no syntax errors.
- [x] Wrote a one-off script to walk every `$ref` in the parsed document and confirm it resolves — all 81 refs (including the new ones added here) resolve correctly.
- [x] Cross-checked every changed field's actual runtime type against the corresponding route source and its existing test mocks (`markets.test.ts`, `funding.test.ts`) before changing its documented type.
- [x] Full test suite still passes (294/295 — the 1 pre-existing failure is unrelated to this change, in `adl.test.ts`); `tsc --noEmit` clean (expected, since this PR touches no `.ts` files).