### PR TITLE
fix(api): stop logging raw Error objects in 4 catch blocks [BUG-113]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -393,7 +393,9 @@ async function shutdown(signal: string): Promise<void> {
     logger.info("Shutdown complete");
     process.exit(0);
   } catch (err) {
-    logger.error("Error during shutdown", { error: err });
+    logger.error("Error during shutdown", {
+      error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120),
+    });
     process.exit(1);
   }
 }
@@ -401,7 +403,10 @@ async function shutdown(signal: string): Promise<void> {
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("uncaughtException", (err) => {
-  logger.error("Uncaught exception", { error: err.message, stack: err.stack });
+  logger.error("Uncaught exception", {
+    error: truncateErrorMessage(err.message, 120),
+    stack: truncateErrorMessage(err.stack ?? "", 500),
+  });
   shutdown("uncaughtException");
 });
 process.on("unhandledRejection", (reason) => {

--- a/src/routes/chart.ts
+++ b/src/routes/chart.ts
@@ -21,7 +21,7 @@
  */
 import { Hono } from "hono";
 import { PublicKey } from "@solana/web3.js";
-import { createLogger } from "@percolator/shared";
+import { createLogger, truncateErrorMessage } from "@percolator/shared";
 
 const logger = createLogger("api:chart");
 
@@ -88,7 +88,7 @@ async function getTopPool(mint: string): Promise<string | null> {
     }
     return raw;
   } catch (err) {
-    logger.warn("getTopPool fetch error", { mint, err });
+    logger.warn("getTopPool fetch error", { mint, error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120) });
     return null;
   } finally {
     clearTimeout(timer);
@@ -133,7 +133,7 @@ async function fetchOhlcv(
         .sort((a, b) => a.timestamp - b.timestamp)
     );
   } catch (err) {
-    logger.warn("fetchOhlcv error", { poolAddress, err });
+    logger.warn("fetchOhlcv error", { poolAddress, error: truncateErrorMessage(err instanceof Error ? err.message : String(err), 120) });
     return [];
   } finally {
     clearTimeout(timer);

--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -1112,7 +1112,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
           }
         }
       } catch (err) {
-        logger.warn("Error processing WS message", { ip: client.ip, error: err });
+        logger.warn("Error processing WS message", { ip: client.ip, error: err instanceof Error ? err.message : String(err) });
         safeSend(ws, { type: "error", message: "Invalid message" });
       }
     });

--- a/tests/routes/chart.test.ts
+++ b/tests/routes/chart.test.ts
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vites
 import { chartRoutes } from "../../src/routes/chart.js";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
+// A single shared logger instance (not a fresh object per createLogger()
+// call) so tests can assert on calls made by chart.ts's module-scoped
+// `logger`, which is only constructed once at import time.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
 vi.mock("@percolator/shared", () => ({
-  createLogger: vi.fn(() => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  })),
+  createLogger: vi.fn(() => mockLogger),
+  truncateErrorMessage: (msg: unknown, maxLength = 120) => {
+    const str = typeof msg === "string" ? msg : String(msg);
+    return str.length > maxLength ? str.slice(0, maxLength) + "..." : str;
+  },
 }));
 
 // Mock global fetch
@@ -100,6 +106,44 @@ describe("GET /chart/:mint", () => {
     const body = await res.json();
     expect(body.candles).toEqual([]);
     expect(body.poolAddress).toBeNull();
+  });
+
+  describe("error logging (BUG-113)", () => {
+    it("logs a truncated string (not the raw Error object) when the pool fetch throws", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("network exploded"));
+
+      const app = makeApp();
+      const res = await app.request(
+        new Request(`http://localhost/chart/${VALID_MINT}?_nocache=logtest1`)
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.candles).toEqual([]);
+
+      const call = mockLogger.warn.mock.calls.find((c) => c[0] === "getTopPool fetch error");
+      expect(call).toBeDefined();
+      expect(typeof call![1].error).toBe("string");
+      expect(call![1].error).toContain("network exploded");
+    });
+
+    it("logs a truncated string (not the raw Error object) when the OHLCV fetch throws", async () => {
+      mockFetch
+        .mockResolvedValueOnce(makeJsonRes(MOCK_POOL_RES))
+        .mockRejectedValueOnce(new Error("ohlcv exploded"));
+
+      const app = makeApp();
+      const res = await app.request(
+        new Request(`http://localhost/chart/${VALID_MINT}?_nocache=logtest2`)
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.candles).toEqual([]);
+
+      const call = mockLogger.warn.mock.calls.find((c) => c[0] === "fetchOhlcv error");
+      expect(call).toBeDefined();
+      expect(typeof call![1].error).toBe("string");
+      expect(call![1].error).toContain("ohlcv exploded");
+    });
   });
 
   it("returns OHLCV candles on success", async () => {

--- a/tests/routes/ws-error-logging.test.ts
+++ b/tests/routes/ws-error-logging.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression: the WS message-handler catch block must log a string error
+ * message, not the raw Error object, matching every other catch in this
+ * file (BUG-113).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import WebSocket from "ws";
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => mockLogger),
+  eventBus: { on: vi.fn() },
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          abortSignal: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+          })),
+          single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+        })),
+      })),
+    })),
+  })),
+  sanitizeSlabAddress: vi.fn((s: string) => s),
+  sendInfoAlert: vi.fn(),
+}));
+
+interface TestServer {
+  server: http.Server;
+  port: number;
+}
+
+async function startServer(): Promise<TestServer> {
+  Object.assign(process.env, { NODE_ENV: "test", WS_AUTH_REQUIRED: "false" });
+  vi.resetModules();
+  const { setupWebSocket } = await import("../../src/routes/ws.js");
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+  setupWebSocket(server as unknown as import("node:http").Server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as { port: number };
+  return { server, port };
+}
+
+function stopServer(ts: TestServer): Promise<void> {
+  return new Promise((resolve, reject) =>
+    ts.server.close((err) => (err ? reject(err) : resolve())),
+  );
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) return resolve();
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+}
+
+describe("WS message handler — error logging (BUG-113)", () => {
+  let ts: TestServer;
+
+  beforeEach(() => {
+    mockLogger.warn.mockClear();
+  });
+
+  afterEach(async () => {
+    if (ts) await stopServer(ts);
+    delete process.env.WS_AUTH_REQUIRED;
+  });
+
+  it("logs a string error message (not the raw Error object) for a malformed message", async () => {
+    ts = await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${ts.port}/`);
+    await waitForOpen(ws);
+
+    try {
+      ws.send("not valid json {{{");
+      await new Promise((r) => setTimeout(r, 50));
+
+      const call = mockLogger.warn.mock.calls.find((c) => c[0] === "Error processing WS message");
+      expect(call).toBeDefined();
+      expect(typeof call![1].error).toBe("string");
+    } finally {
+      ws.close();
+    }
+  });
+});


### PR DESCRIPTION
## Bug
Four catch blocks log the raw `Error` object (or an untruncated `.message`/`.stack`) directly into structured logging calls, instead of following the `truncateErrorMessage(...)` convention this codebase already established (see BUG-007, PR #216):

- `src/index.ts`'s `shutdown()` catch (`{ error: err }`) and the `uncaughtException` handler (`{ error: err.message, stack: err.stack }`, untruncated).
- `src/routes/ws.ts`'s WS message-handler catch (`{ ip: client.ip, error: err }`) — the one outlier among ~9 other catches in this same file, all of which already extract `err.message`.
- `src/routes/chart.ts`'s `getTopPool` and `fetchOhlcv` catches (`{ mint, err }` / `{ poolAddress, err }`).

A raw `Error` object in a log call carries an unbounded stack trace, and depending on the logger/transport's serialization, can blow up log line size or fail to serialize cleanly at all (circular refs, non-enumerable properties).

## Fix
- `ws.ts` and `chart.ts`'s outlier catches now extract `err instanceof Error ? err.message : String(err)`, matching their own file's existing pattern (`ws.ts`) or the codebase-wide `truncateErrorMessage(...)` pattern (`chart.ts`, which had no prior local convention to match).
- `index.ts`'s `uncaughtException` handler now mirrors the exact truncation pattern its own generic Hono error handler already uses ~190 lines above it: message capped at 120 chars via `truncateErrorMessage`, stack capped at 500. The `shutdown()` catch immediately above it had the identical raw-object pattern, so it's fixed the same way as part of the same change.

`index.ts` itself has no unit tests anywhere in this codebase (it has real side effects on import — this is why BUG-102 extracted `shutdown.ts` separately), so there's no test to add for that file's two catches; the fix there is a direct, low-risk mirror of an already-tested-by-precedent in-file pattern.

## Test plan
- [x] Added an `error logging (BUG-113)` block to `tests/routes/chart.test.ts`: forces `getTopPool`'s and `fetchOhlcv`'s `fetch` calls to reject, asserts the logged `error` field is a string containing the original message rather than the raw `Error` object.
- [x] Added `tests/routes/ws-error-logging.test.ts`: spins up a real WS server, sends a malformed (non-JSON) message to trigger the message-handler catch, asserts the logged `error` field is a string.
- [x] Verified all 3 new/changed assertions are genuine regressions: reverted `src/index.ts`/`src/routes/ws.ts`/`src/routes/chart.ts` via `git stash`, confirmed the new tests fail against the unfixed code, restored the fix.
- [x] Full suite passes (297/298 — the 1 pre-existing failure is unrelated to this change, in `adl.test.ts`).
- [x] `tsc --noEmit` clean.