### PR TITLE
fix(security): default TRUSTED_PROXY_DEPTH to fail closed

### DIFF
--- a/src/middleware/ip-blocklist.ts
+++ b/src/middleware/ip-blocklist.ts
@@ -19,10 +19,10 @@ const logger = createLogger("api:ip-blocklist");
  */
 
 const PROXY_DEPTH = (() => {
-  const parsed = Number(process.env.TRUSTED_PROXY_DEPTH ?? 1);
+  const parsed = Number(process.env.TRUSTED_PROXY_DEPTH ?? 0);
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
     logger.warn("Invalid TRUSTED_PROXY_DEPTH, falling back to default", { value: process.env.TRUSTED_PROXY_DEPTH });
-    return 1;
+    return 0;
   }
   return parsed;
 })();

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -29,10 +29,10 @@ setInterval(() => {
  * no trusted proxy is configured.
  */
 const PROXY_DEPTH = (() => {
-  const parsed = Number(process.env.TRUSTED_PROXY_DEPTH ?? 1);
+  const parsed = Number(process.env.TRUSTED_PROXY_DEPTH ?? 0);
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
     logger.warn("Invalid TRUSTED_PROXY_DEPTH, falling back to default", { value: process.env.TRUSTED_PROXY_DEPTH });
-    return 1;
+    return 0;
   }
   return parsed;
 })();

--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -262,10 +262,10 @@ setInterval(() => {
  * See rate-limit.ts for full documentation.
  */
 const WS_PROXY_DEPTH = (() => {
-  const parsed = Number(process.env.TRUSTED_PROXY_DEPTH ?? 1);
+  const parsed = Number(process.env.TRUSTED_PROXY_DEPTH ?? 0);
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
     logger.warn("Invalid TRUSTED_PROXY_DEPTH, falling back to default", { value: process.env.TRUSTED_PROXY_DEPTH });
-    return 1;
+    return 0;
   }
   return parsed;
 })();

--- a/tests/middleware/proxy-depth-default.test.ts
+++ b/tests/middleware/proxy-depth-default.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("@percolator/shared", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+describe("TRUSTED_PROXY_DEPTH secure default behavior", () => {
+  const oldDepth = process.env.TRUSTED_PROXY_DEPTH;
+  const oldBlocklist = process.env.IP_BLOCKLIST;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@hono/node-server/conninfo");
+    delete process.env.TRUSTED_PROXY_DEPTH;
+    delete process.env.IP_BLOCKLIST;
+  });
+
+  afterEach(() => {
+    if (oldDepth === undefined) delete process.env.TRUSTED_PROXY_DEPTH;
+    else process.env.TRUSTED_PROXY_DEPTH = oldDepth;
+
+    if (oldBlocklist === undefined) delete process.env.IP_BLOCKLIST;
+    else process.env.IP_BLOCKLIST = oldBlocklist;
+
+    vi.doUnmock("@hono/node-server/conninfo");
+    vi.resetModules();
+  });
+
+  function mockSocketIp(ip: string) {
+    vi.doMock("@hono/node-server/conninfo", () => ({
+      getConnInfo: vi.fn(() => ({
+        remote: {
+          address: ip,
+        },
+      })),
+    }));
+  }
+
+  it("Regression: unset TRUSTED_PROXY_DEPTH ignores spoofed X-Forwarded-For and rate-limits by socket IP", async () => {
+    mockSocketIp("10.0.0.1");
+
+    const { readRateLimit } = await import("../../src/middleware/rate-limit.js");
+    const { resetSharedStore, InMemoryStore } = await import("../../src/middleware/shared-store.js");
+
+    resetSharedStore(new InMemoryStore());
+
+    const app = new Hono();
+    app.get("/test", readRateLimit(), (c) => c.json({ ok: true }));
+
+    // Even though X-Forwarded-For rotates, the secure default must ignore it.
+    // All requests should count against the mocked socket IP bucket.
+    for (let i = 0; i < 100; i++) {
+      const res = await app.request("/test", {
+        headers: {
+          "x-forwarded-for": `198.51.100.${i}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await app.request("/test", {
+      headers: {
+        "x-forwarded-for": "198.51.100.250",
+      },
+    });
+
+    expect(blocked.status).toBe(429);
+  });
+
+  it("Regression: unset TRUSTED_PROXY_DEPTH uses socket IP for blocklist decision, not spoofed X-Forwarded-For", async () => {
+    process.env.IP_BLOCKLIST = "10.0.0.1";
+    mockSocketIp("10.0.0.1");
+
+    const { ipBlocklist } = await import("../../src/middleware/ip-blocklist.js");
+
+    const app = new Hono();
+    app.get("/test", ipBlocklist(), (c) => c.json({ ok: true }));
+
+    const res = await app.request("/test", {
+      headers: {
+        "x-forwarded-for": "198.51.100.77",
+      },
+    });
+
+    // X-Forwarded-For is not blocklisted, but the socket IP is.
+    // With the secure default, the request must be blocked.
+    expect(res.status).toBe(403);
+  });
+
+  it("Explicit proxy mode: TRUSTED_PROXY_DEPTH=1 can still use X-Forwarded-For when intentionally configured", async () => {
+    process.env.TRUSTED_PROXY_DEPTH = "1";
+    process.env.IP_BLOCKLIST = "203.0.113.10";
+    mockSocketIp("10.0.0.1");
+
+    const { ipBlocklist } = await import("../../src/middleware/ip-blocklist.js");
+
+    const app = new Hono();
+    app.get("/test", ipBlocklist(), (c) => c.json({ ok: true }));
+
+    const blockedViaTrustedProxyHeader = await app.request("/test", {
+      headers: {
+        "x-forwarded-for": "203.0.113.10",
+      },
+    });
+
+    expect(blockedViaTrustedProxyHeader.status).toBe(403);
+
+    const allowedViaTrustedProxyHeader = await app.request("/test", {
+      headers: {
+        "x-forwarded-for": "198.51.100.77",
+      },
+    });
+
+    expect(allowedViaTrustedProxyHeader.status).toBe(200);
+  });
+});

--- a/tests/middleware/rate-limit.test.ts
+++ b/tests/middleware/rate-limit.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
 import { Hono } from "hono";
+
+// These existing rate-limit tests intentionally exercise trusted-proxy
+// X-Forwarded-For parsing. The secure fail-closed default is covered by
+// tests/middleware/proxy-depth-default.test.ts.
+const originalTrustedProxyDepth = vi.hoisted(() => process.env.TRUSTED_PROXY_DEPTH);
+
+vi.hoisted(() => {
+  process.env.TRUSTED_PROXY_DEPTH = "1";
+});
+
+afterAll(() => {
+  if (originalTrustedProxyDepth === undefined) delete process.env.TRUSTED_PROXY_DEPTH;
+  else process.env.TRUSTED_PROXY_DEPTH = originalTrustedProxyDepth;
+});
 
 vi.mock("@percolator/shared", () => ({
   createLogger: vi.fn(() => ({


### PR DESCRIPTION
## Summary

Fixes #230.

This PR makes client-IP extraction fail closed by default by changing the default `TRUSTED_PROXY_DEPTH` from `1` to `0`.

Previously, when `TRUSTED_PROXY_DEPTH` was unset, the API assumed one trusted proxy and consumed `X-Forwarded-For` as trusted input. Since `X-Forwarded-For` is client-controllable unless it is stripped or rewritten by a trusted reverse proxy, this could allow spoofed-IP behavior to influence HTTP rate limiting, IP blocklist decisions, and WebSocket abuse controls.

With this change, forwarded headers are ignored unless operators explicitly opt in by setting `TRUSTED_PROXY_DEPTH=1`.

## What Changed

This PR updates all client-IP extraction paths that previously defaulted to trusting one proxy:

* `src/middleware/rate-limit.ts`
* `src/middleware/ip-blocklist.ts`
* `src/routes/ws.ts`

The default trusted proxy depth is changed from:

```ts
process.env.TRUSTED_PROXY_DEPTH ?? 1
```

to:

```ts
process.env.TRUSTED_PROXY_DEPTH ?? 0
```

The invalid-config fallback is also changed from fail-open to fail-closed:

```diff
- return 1;
+ return 0;
```

This means that if `TRUSTED_PROXY_DEPTH` is missing or invalid, the application no longer trusts client-supplied forwarded headers by default.

## Why This Fix Is Needed

`X-Forwarded-For` should only be trusted when the application is deployed behind a trusted proxy or load balancer that sanitizes the header.

Before this change, the application defaulted to `TRUSTED_PROXY_DEPTH=1`, which means requests with an `X-Forwarded-For` header could influence the client IP used by abuse-control logic even when the operator did not explicitly configure proxy trust.

That client IP is used in multiple security-sensitive paths:

* HTTP read rate limiting
* HTTP write rate limiting
* IP blocklist enforcement
* WebSocket IP blocklist checks
* WebSocket auth-failure bans
* WebSocket authenticated per-IP connection caps
* WebSocket unauthenticated per-IP connection caps

Defaulting to `0` makes the behavior fail closed. Deployments that intentionally rely on trusted proxy headers can still opt in explicitly with:

```env
TRUSTED_PROXY_DEPTH=1
```

## Test Changes

This PR adds regression coverage in:

```txt
tests/middleware/proxy-depth-default.test.ts
```

The new tests verify that:

1. When `TRUSTED_PROXY_DEPTH` is unset, spoofed `X-Forwarded-For` values are ignored for HTTP rate limiting.
2. When `TRUSTED_PROXY_DEPTH` is unset, the IP blocklist decision uses the socket IP instead of spoofed `X-Forwarded-For`.
3. Explicit trusted-proxy mode still works when `TRUSTED_PROXY_DEPTH=1`.

This PR also updates the existing rate-limit middleware tests to explicitly exercise trusted-proxy behavior with `TRUSTED_PROXY_DEPTH=1`.

That keeps existing `X-Forwarded-For` rate-limit behavior covered, while the new regression test covers the secure default.

## Testing

Relevant middleware tests passed locally:

```bash
./node_modules/.bin/vitest run tests/middleware --reporter=verbose
```

Result:

```txt
Test Files  7 passed (7)
Tests       82 passed (82)
```

I also ran the broader Vitest suite locally. The full suite currently reaches unrelated failures in `tests/sdk-smoke.test.ts` because local devnet v17 `PROGRAM_ID` / `MATCHER_PROGRAM_ID` environment variables are not configured:

```txt
Percolator v17 program is not deployed for devnet
Percolator v17 matcher program is not deployed for devnet
```

Those SDK smoke failures are unrelated to this PR's middleware changes.

## Notes

This PR does not remove trusted-proxy support.

It only changes the default behavior so that forwarded-header trust is explicit instead of enabled by default. Operators who deploy behind a trusted proxy can continue using forwarded headers by setting:

```env
TRUSTED_PROXY_DEPTH=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how client IPs are determined when proxy depth is not configured or is invalid.
  * Requests now default to using the direct connection IP instead of trusting forwarded headers by default.
  * This changes rate limiting and IP blocklist behavior to be more secure when proxy settings are absent.

* **Tests**
  * Added and updated coverage for proxy-depth defaults and forwarded IP handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->