### PR TITLE
ci(sdk-smoke): check out percolator-sdk as a sibling so the nightly can install (#232)

### DIFF
--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -73,6 +73,28 @@ jobs:
       # packages (hono, vitest, @solana/web3.js …) are present, then override
       # only the SDK dep to the target npm version.  --no-frozen-lockfile is
       # intentional: we are mutating one dep, not reproducing a build.
+      # #232: package.json + pnpm-lock.yaml resolve @percolatorct/sdk as
+      # `file:../../percolator-sdk`, so a bare checkout has no SDK to install and
+      # the install below dies with
+      # `ENOENT ... scandir '<runner>/work/percolator-sdk'` (exit 254) — which is
+      # what this nightly has actually been failing on, before any SDK version is
+      # ever resolved. ci.yml gets this treatment in #233; sdk-smoke.yml was left
+      # out, so the smoke stayed red even with a correct pin.
+      # Path is TWO levels up: from `<runner>/work/percolator-api/percolator-api`
+      # that is `<runner>/work`. actions/checkout cannot write outside
+      # GITHUB_WORKSPACE, so check out into the workspace and then move it up.
+      # percolator-sdk is public, so the default token suffices.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: dcccrypto/percolator-sdk
+          ref: main
+          path: _percolator-sdk
+      - name: Place @percolatorct/sdk as a sibling checkout (#232)
+        run: |
+          rm -rf ../../percolator-sdk
+          mv _percolator-sdk ../../percolator-sdk
+          test -f ../../percolator-sdk/dist/index.js || { echo "SDK dist/ missing — the SDK repo ships a committed dist; aborting"; exit 1; }
+
       - name: Install dependencies (frozen lockfile for non-SDK packages)
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Fixes the `SDK publish smoke` nightly, which has failed every run for at least a
week.

## It never reaches an assertion

```
ENOENT: no such file or directory, scandir '/home/runner/work/percolator-sdk'
Process completed with exit code 254
```

`package.json` / `pnpm-lock.yaml` resolve `@percolatorct/sdk` as
`file:../../percolator-sdk`, so a bare checkout has no SDK to install. #233 adds
the sibling checkout to `ci.yml`; **`sdk-smoke.yml` was left out**, so this
nightly stays red no matter what version is pinned.

## The pin is not the problem here — and that matters

The two sibling repos' nightlies were also red, and both needed a **version
bump** (percolator-keeper#395, percolator-indexer#192: their smoke suites moved to
v17 assertions while their pins stayed at 2.0.5). The obvious inference is that
this repo needs the same. **It doesn't**, and I checked rather than assuming —
this repo's pin is `1.0.0-beta.33`, which looks even more stale, so the inference
was tempting.

Ran this repo's own `tests/sdk-smoke.test.ts` against both:

```
@percolatorct/sdk@1.0.0-beta.33  →  30 passed (30)
@percolatorct/sdk@4.3.0          →  30 passed (30)
```

Both green. This repo's smoke asserts stable surface (`SLAB_MAGIC`, `ENGINE_OFF`,
`parseHeader`, …) rather than v17-specific behaviour, so the pin is fine and
bumping it would be unverified churn.

**Three red nightlies, two distinct causes** — worth stating plainly since fixing
them looked like one job:

| repo | cause | fix |
|---|---|---|
| percolator-keeper | stale pin vs v17 assertions | #395 |
| percolator-indexer | stale pin vs v17 assertions | #192 |
| **percolator-api** | **missing sibling checkout** | **this PR** |

## The change

Copies the block #233 adds to `ci.yml` verbatim, including the two-levels-up path
note — from `<runner>/work/percolator-api/percolator-api` that is `<runner>/work`,
which differs from percolator-indexer#172's one level. YAML validated.

## Related: #233 is blocking the PR queue

While confirming this I checked my other open PRs here. #235, #236, #237 and #239
all fail `build-and-test` with the **same ENOENT**, on runs from 2026-07-20 —
i.e. they are blocked by the unfixed CI, not by their own content. #233 is green
on `build-and-test` and fixes that for `ci.yml`.

So #233 unblocks the PR queue, and this PR unblocks the nightly. They are
independent files and can land in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK smoke workflow to use the latest `percolator-sdk` main branch.
  * Added validation that the SDK distribution file is available before installing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->